### PR TITLE
Import improvements: exclude, nulls not distinct, enum types, introspect fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to PgDesigner
+
+Thank you for your interest in contributing to PgDesigner!
+
+## Contributor License Agreement (CLA)
+
+By submitting a pull request or otherwise contributing code to this repository, you agree to the following terms:
+
+1. You grant **vmkteam** and the project maintainers a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to use, reproduce, modify, distribute, sublicense, and otherwise exploit your contribution in any form, including under the project's commercial license.
+
+2. You confirm that you are the original author of the contribution, or that you have the right to submit it under these terms.
+
+3. You understand that your contribution will be licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE) for public use, and may also be distributed under a separate [commercial license](LICENSE-COMMERCIAL.md).
+
+4. You are not expected to provide support for your contribution, but you may be asked to clarify or improve it during the review process.
+
+## How to Contribute
+
+1. Fork the repository and create a branch for your changes.
+2. Make your changes and ensure tests pass (`make test`).
+3. Submit a pull request with a clear description of what you changed and why.
+
+## Code Style
+
+- Go: simple, clear, no magic. Prefer stdlib over third-party. Error handling with context wrapping.
+- Commit messages: concise, English, lowercase.
+
+## Questions?
+
+If you have any questions about contributing, feel free to open an issue or contact us at [sergeyfast@gmail.com](mailto:sergeyfast@gmail.com).

--- a/demo/schemas/pgd/adventureworks.pgd
+++ b/demo/schemas/pgd/adventureworks.pgd
@@ -79,8 +79,8 @@
       <column name="loginid" type="varchar" length="256" nullable="false"></column>
       <column name="jobtitle" type="varchar" length="50" nullable="false"></column>
       <column name="birthdate" type="date" nullable="false"></column>
-      <column name="maritalstatus" type="bpchar" nullable="false"></column>
-      <column name="gender" type="bpchar" nullable="false"></column>
+      <column name="maritalstatus" type="char" length="1" nullable="false"></column>
+      <column name="gender" type="char" length="1" nullable="false"></column>
       <column name="hiredate" type="date" nullable="false"></column>
       <column name="salariedflag" type="Flag" nullable="false" default="true"></column>
       <column name="vacationhours" type="smallint" nullable="false" default="0"></column>
@@ -88,7 +88,7 @@
       <column name="currentflag" type="Flag" nullable="false" default="true"></column>
       <column name="rowguid" type="uuid" nullable="false" default="public.uuid_generate_v1()"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
-      <column name="organizationnode" type="varchar" default="&#39;/&#39;::varchar"></column>
+      <column name="organizationnode" type="varchar" default="&#39;/&#39;"></column>
       <pk name="PK_Employee_BusinessEntityID">
         <column name="businessentityid"></column>
       </pk>
@@ -288,7 +288,7 @@
     </table>
     <table name="person">
       <column name="businessentityid" type="integer" nullable="false"></column>
-      <column name="persontype" type="bpchar" nullable="false"></column>
+      <column name="persontype" type="char" length="2" nullable="false"></column>
       <column name="namestyle" type="NameStyle" nullable="false" default="false"></column>
       <column name="title" type="varchar" length="8"></column>
       <column name="firstname" type="Name" nullable="false"></column>
@@ -336,7 +336,7 @@
     </table>
     <table name="stateprovince">
       <column name="stateprovinceid" type="integer" nullable="false"></column>
-      <column name="stateprovincecode" type="bpchar" nullable="false"></column>
+      <column name="stateprovincecode" type="char" length="3" nullable="false"></column>
       <column name="countryregioncode" type="varchar" length="3" nullable="false"></column>
       <column name="isonlystateprovinceflag" type="Flag" nullable="false" default="true"></column>
       <column name="name" type="Name" nullable="false"></column>
@@ -366,7 +366,7 @@
       <column name="componentid" type="integer" nullable="false"></column>
       <column name="startdate" type="timestamp" nullable="false" default="now()"></column>
       <column name="enddate" type="timestamp"></column>
-      <column name="unitmeasurecode" type="bpchar" nullable="false"></column>
+      <column name="unitmeasurecode" type="char" length="3" nullable="false"></column>
       <column name="bomlevel" type="smallint" nullable="false"></column>
       <column name="perassemblyqty" type="numeric" precision="8" scale="2" nullable="false" default="1.00"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
@@ -388,7 +388,7 @@
       <check name="CK_BillOfMaterials_ProductAssemblyID"><![CDATA[productassemblyid <> componentid]]></check>
     </table>
     <table name="culture">
-      <column name="cultureid" type="bpchar" nullable="false"></column>
+      <column name="cultureid" type="char" length="6" nullable="false"></column>
       <column name="name" type="Name" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
       <pk name="PK_Culture_CultureID">
@@ -401,14 +401,14 @@
       <column name="folderflag" type="Flag" nullable="false" default="false"></column>
       <column name="filename" type="varchar" length="400" nullable="false"></column>
       <column name="fileextension" type="varchar" length="8"></column>
-      <column name="revision" type="bpchar" nullable="false"></column>
+      <column name="revision" type="char" length="5" nullable="false"></column>
       <column name="changenumber" type="integer" nullable="false" default="0"></column>
       <column name="status" type="smallint" nullable="false"></column>
       <column name="documentsummary" type="text"></column>
       <column name="document" type="bytea"></column>
       <column name="rowguid" type="uuid" nullable="false" default="public.uuid_generate_v1()"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
-      <column name="documentnode" type="varchar" nullable="false" default="&#39;/&#39;::varchar"></column>
+      <column name="documentnode" type="varchar" nullable="false" default="&#39;/&#39;"></column>
       <pk name="PK_Document_DocumentNode">
         <column name="documentnode"></column>
       </pk>
@@ -452,13 +452,13 @@
       <column name="standardcost" type="numeric" nullable="false"></column>
       <column name="listprice" type="numeric" nullable="false"></column>
       <column name="size" type="varchar" length="5"></column>
-      <column name="sizeunitmeasurecode" type="bpchar"></column>
-      <column name="weightunitmeasurecode" type="bpchar"></column>
+      <column name="sizeunitmeasurecode" type="char" length="3"></column>
+      <column name="weightunitmeasurecode" type="char" length="3"></column>
       <column name="weight" type="numeric" precision="8" scale="2"></column>
       <column name="daystomanufacture" type="integer" nullable="false"></column>
-      <column name="productline" type="bpchar"></column>
-      <column name="class" type="bpchar"></column>
-      <column name="style" type="bpchar"></column>
+      <column name="productline" type="char" length="2"></column>
+      <column name="class" type="char" length="2"></column>
+      <column name="style" type="char" length="2"></column>
       <column name="productsubcategoryid" type="integer"></column>
       <column name="productmodelid" type="integer"></column>
       <column name="sellstartdate" type="timestamp" nullable="false"></column>
@@ -529,7 +529,7 @@
     <table name="productdocument">
       <column name="productid" type="integer" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
-      <column name="documentnode" type="varchar" nullable="false" default="&#39;/&#39;::varchar"></column>
+      <column name="documentnode" type="varchar" nullable="false" default="&#39;/&#39;"></column>
       <pk name="PK_ProductDocument_ProductID_DocumentNode">
         <column name="productid"></column>
         <column name="documentnode"></column>
@@ -606,7 +606,7 @@
     <table name="productmodelproductdescriptionculture">
       <column name="productmodelid" type="integer" nullable="false"></column>
       <column name="productdescriptionid" type="integer" nullable="false"></column>
-      <column name="cultureid" type="bpchar" nullable="false"></column>
+      <column name="cultureid" type="char" length="6" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
       <pk name="PK_ProductModelProductDescriptionCulture_ProductModelID_Product">
         <column name="productmodelid"></column>
@@ -691,7 +691,7 @@
       <column name="referenceorderid" type="integer" nullable="false"></column>
       <column name="referenceorderlineid" type="integer" nullable="false" default="0"></column>
       <column name="transactiondate" type="timestamp" nullable="false" default="now()"></column>
-      <column name="transactiontype" type="bpchar" nullable="false"></column>
+      <column name="transactiontype" type="char" length="1" nullable="false"></column>
       <column name="quantity" type="integer" nullable="false"></column>
       <column name="actualcost" type="numeric" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
@@ -709,7 +709,7 @@
       <column name="referenceorderid" type="integer" nullable="false"></column>
       <column name="referenceorderlineid" type="integer" nullable="false" default="0"></column>
       <column name="transactiondate" type="timestamp" nullable="false" default="now()"></column>
-      <column name="transactiontype" type="bpchar" nullable="false"></column>
+      <column name="transactiontype" type="char" length="1" nullable="false"></column>
       <column name="quantity" type="integer" nullable="false"></column>
       <column name="actualcost" type="numeric" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
@@ -719,7 +719,7 @@
       <check name="CK_TransactionHistoryArchive_TransactionType"><![CDATA[upper(transactiontype::text) = ANY(ARRAY['W'::text, 'S'::text, 'P'::text])]]></check>
     </table>
     <table name="unitmeasure">
-      <column name="unitmeasurecode" type="bpchar" nullable="false"></column>
+      <column name="unitmeasurecode" type="char" length="3" nullable="false"></column>
       <column name="name" type="Name" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
       <pk name="PK_UnitMeasure_UnitMeasureCode">
@@ -796,7 +796,7 @@
       <column name="minorderqty" type="integer" nullable="false"></column>
       <column name="maxorderqty" type="integer" nullable="false"></column>
       <column name="onorderqty" type="integer"></column>
-      <column name="unitmeasurecode" type="bpchar" nullable="false"></column>
+      <column name="unitmeasurecode" type="char" length="3" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
       <pk name="PK_ProductVendor_ProductID_BusinessEntityID">
         <column name="productid"></column>
@@ -909,7 +909,7 @@
   <schema name="sales">
     <table name="countryregioncurrency">
       <column name="countryregioncode" type="varchar" length="3" nullable="false"></column>
-      <column name="currencycode" type="bpchar" nullable="false"></column>
+      <column name="currencycode" type="char" length="3" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
       <pk name="PK_CountryRegionCurrency_CountryRegionCode_CurrencyCode">
         <column name="countryregioncode"></column>
@@ -934,7 +934,7 @@
       </pk>
     </table>
     <table name="currency">
-      <column name="currencycode" type="bpchar" nullable="false"></column>
+      <column name="currencycode" type="char" length="3" nullable="false"></column>
       <column name="name" type="Name" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
       <pk name="PK_Currency_CurrencyCode">
@@ -944,8 +944,8 @@
     <table name="currencyrate">
       <column name="currencyrateid" type="integer" nullable="false"></column>
       <column name="currencyratedate" type="timestamp" nullable="false"></column>
-      <column name="fromcurrencycode" type="bpchar" nullable="false"></column>
-      <column name="tocurrencycode" type="bpchar" nullable="false"></column>
+      <column name="fromcurrencycode" type="char" length="3" nullable="false"></column>
+      <column name="tocurrencycode" type="char" length="3" nullable="false"></column>
       <column name="averagerate" type="numeric" nullable="false"></column>
       <column name="endofdayrate" type="numeric" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>

--- a/pkg/format/pdd/pdd.go
+++ b/pkg/format/pdd/pdd.go
@@ -31,7 +31,16 @@ type PDD struct {
 	ModelSettings PDDSettings `xml:"MODELSETTINGS"`
 	Schemas       []PDDSchema `xml:"SCHEMAS>SCHEMA"`
 	Domains       []PDDDomain `xml:"DOMAINS>DOMAIN"`
+	Enums         []PDDEnum   `xml:"ENUMS>ENUM"`
 	Metadata      PDDMetadata `xml:"METADATA"`
+}
+
+type PDDEnum struct {
+	ID         int    `xml:"ID,attr"`
+	Name       string `xml:"Name,attr"`
+	SchemaName string `xml:"SchemaName,attr"`
+	Values     string `xml:"Values,attr"`
+	Comments   string `xml:"Comments,attr"`
 }
 
 type PDDSettings struct {
@@ -101,14 +110,15 @@ type PDDCText struct {
 }
 
 type PDDIndex struct {
-	ID        int      `xml:"ID,attr"`
-	Name      string   `xml:"Name,attr"`
-	Unique    int      `xml:"Unique,attr"`
-	Method    int      `xml:"Method,attr"`
-	Predicate string   `xml:"Predicate,attr"`
-	RawCols   PDDCText `xml:"INDEXCOLUMNS"`
-	RawSorts  PDDCText `xml:"INDEXSORTS"`
-	RawNulls  PDDCText `xml:"INDEXNULLS"`
+	ID                  int      `xml:"ID,attr"`
+	Name                string   `xml:"Name,attr"`
+	Unique              int      `xml:"Unique,attr"`
+	Method              int      `xml:"Method,attr"`
+	Predicate           string   `xml:"Predicate,attr"`
+	ReferenceConstraint int      `xml:"ReferenceConstraint,attr"`
+	RawCols             PDDCText `xml:"INDEXCOLUMNS"`
+	RawSorts            PDDCText `xml:"INDEXSORTS"`
+	RawNulls            PDDCText `xml:"INDEXNULLS"`
 }
 
 type PDDReference struct {
@@ -136,11 +146,11 @@ func convert(pdd *PDD) *pgd.Project {
 		}
 	}
 
-	// Build domain lookup: quoted name → domain name, and convert to pgd domains.
-	domainNames := make(map[string]string) // quoted name (e.g. `"Name"`) → domain name
+	// Build custom type lookup: quoted PDD name → unquoted pgd name (domains + enums).
+	typeNames := make(map[string]string)
 	var pgdDomains []pgd.Domain
 	for _, d := range pdd.Domains {
-		domainNames[`"`+d.Name+`"`] = d.Name
+		typeNames[`"`+d.Name+`"`] = d.Name
 		baseType := pgd.NormalizeType(d.Type)
 		dom := pgd.Domain{Name: d.Name, Type: baseType}
 		if d.Width > 0 && pgd.NeedsLength(baseType) {
@@ -150,6 +160,27 @@ func convert(pdd *PDD) *pgd.Project {
 			dom.NotNull = &struct{}{}
 		}
 		pgdDomains = append(pgdDomains, dom)
+	}
+
+	var pgdEnums []pgd.Enum
+	var enumComments []pgd.Comment
+	for _, e := range pdd.Enums {
+		typeNames[`"`+e.Name+`"`] = e.Name
+		vals := strings.Split(e.Values, ",")
+		en := pgd.Enum{Name: e.Name, Schema: e.SchemaName}
+		for _, v := range vals {
+			v = strings.TrimSpace(v)
+			if v != "" {
+				en.Labels = append(en.Labels, v)
+			}
+		}
+		pgdEnums = append(pgdEnums, en)
+		if e.Comments != "" {
+			enumComments = append(enumComments, pgd.Comment{
+				On: "type", Schema: e.SchemaName, Name: e.Name,
+				Value: decodeEscape(e.Comments),
+			})
+		}
 	}
 
 	refsByDest := make(map[int][]PDDReference)
@@ -172,7 +203,7 @@ func convert(pdd *PDD) *pgd.Project {
 
 	for i := range pdd.Metadata.Entities {
 		e := &pdd.Metadata.Entities[i]
-		schema.Tables = append(schema.Tables, convertTable(e, refsByDest[e.ID], entityByID, colByID, domainNames))
+		schema.Tables = append(schema.Tables, convertTable(e, refsByDest[e.ID], entityByID, colByID, typeNames))
 		for j := range e.Indexes {
 			if idx := convertIndex(e.Name, &e.Indexes[j]); idx != nil {
 				schema.Indexes = append(schema.Indexes, *idx)
@@ -196,13 +227,17 @@ func convert(pdd *PDD) *pgd.Project {
 	}
 
 	var types *pgd.Types
-	if len(pgdDomains) > 0 {
-		types = &pgd.Types{Domains: pgdDomains}
+	if len(pgdDomains) > 0 || len(pgdEnums) > 0 {
+		types = &pgd.Types{Domains: pgdDomains, Enums: pgdEnums}
 	}
+
+	extensions := detectExtensions(&schema)
 
 	return &pgd.Project{
 		Version: 1, PgVersion: "18", DefaultSchema: schemaName,
-		Types: types,
+		Extensions: extensions,
+		Types:      types,
+		Comments:   enumComments,
 		ProjectMeta: pgd.ProjectMeta{
 			Name: name,
 			Settings: pgd.Settings{
@@ -217,7 +252,7 @@ func convert(pdd *PDD) *pgd.Project {
 	}
 }
 
-func convertTable(e *PDDEntity, refs []PDDReference, entityByID map[int]*PDDEntity, colByID map[int]*PDDColumn, domainNames map[string]string) pgd.Table {
+func convertTable(e *PDDEntity, refs []PDDReference, entityByID map[int]*PDDEntity, colByID map[int]*PDDColumn, typeNames map[string]string) pgd.Table {
 	t := pgd.Table{Name: e.Name}
 	if e.Generate == 0 {
 		t.Generate = "false"
@@ -232,14 +267,14 @@ func convertTable(e *PDDEntity, refs []PDDReference, entityByID map[int]*PDDEnti
 	// columns sorted by position
 	cols := sortedColumns(e.Columns)
 	for i := range cols {
-		t.Columns = append(t.Columns, convertColumn(&cols[i], domainNames))
+		t.Columns = append(t.Columns, convertColumn(&cols[i], typeNames))
 	}
 
 	// PK
 	if names := constraintCols(e, 2, colByID); len(names) > 0 {
 		pkName := constraintName(e, 2)
 		if pkName == "" {
-			pkName = "pk_" + e.Name
+			pkName = e.Name + "_pkey"
 		}
 		t.PK = &pgd.PrimaryKey{Name: pkName, Columns: pgd.ColRefsFromNames(names)}
 	}
@@ -283,16 +318,15 @@ func convertTable(e *PDDEntity, refs []PDDReference, entityByID map[int]*PDDEnti
 	return t
 }
 
-func convertColumn(col *PDDColumn, domainNames map[string]string) pgd.Column {
+func convertColumn(col *PDDColumn, typeNames map[string]string) pgd.Column {
 	decoded := decodeEscape(col.Type)
-	// Check if type is a domain reference (quoted name like "Name" after decode)
-	if dn, ok := domainNames[decoded]; ok {
-		decoded = dn
+	if resolved, ok := typeNames[decoded]; ok {
+		decoded = resolved
 	}
 	typeName := pgd.NormalizeType(decoded)
 	c := pgd.Column{Name: col.Name, Type: typeName}
 
-	if col.Width > 0 && pgd.NeedsLength(typeName) {
+	if col.Width > 0 && pgd.NeedsLength(strings.TrimSuffix(typeName, "[]")) {
 		c.Length = col.Width
 	}
 	if col.Width > 0 && isNumeric(typeName) {
@@ -313,6 +347,16 @@ func convertColumn(col *PDDColumn, domainNames map[string]string) pgd.Column {
 		if col.QuoteDefault == 1 {
 			def = "'" + def + "'"
 		}
+		switch strings.ToLower(def) {
+		case "true", "false":
+			def = strings.ToLower(def)
+		case "null":
+			def = ""
+		}
+		// strip redundant type cast: 'value'::type → 'value'
+		if idx := strings.LastIndex(def, "::"); idx > 0 {
+			def = def[:idx]
+		}
 		c.Default = def
 	}
 
@@ -320,7 +364,8 @@ func convertColumn(col *PDDColumn, domainNames map[string]string) pgd.Column {
 		c.Comment = decodeEscape(col.Comments)
 	}
 
-	if col.AutoInc > 0 {
+	// IDENTITY only valid for integer types (smallint, integer, bigint)
+	if col.AutoInc > 0 && isIdentityType(typeName) {
 		gen := "by-default"
 		if col.AutoInc == 2 {
 			gen = "always"
@@ -385,7 +430,7 @@ func findColInEntity(e *PDDEntity, id int) *PDDColumn {
 }
 
 func convertIndex(tableName string, idx *PDDIndex) *pgd.Index {
-	if idx.Name == "" {
+	if idx.Name == "" || idx.ReferenceConstraint != 0 {
 		return nil
 	}
 	cols := parseCommaText(decodeEscape(idx.RawCols.Text))
@@ -490,7 +535,7 @@ func resolveColNames(con *PDDConstraint, colByID map[int]*PDDColumn) []string {
 	return names
 }
 
-// decodeEscape converts PDD proprietary escaping: \a=' \A=" \g=> \k=< \n=newline
+// decodeEscape converts PDD proprietary escaping: \a=' \A=" \g=> \k=< \n=newline \NNNN=Unicode
 func decodeEscape(s string) string {
 	if s == "" {
 		return ""
@@ -502,19 +547,35 @@ func decodeEscape(s string) string {
 			switch s[i+1] {
 			case 'a':
 				b.WriteByte('\'')
+				i++
+				continue
 			case 'A':
 				b.WriteByte('"')
+				i++
+				continue
 			case 'g':
 				b.WriteByte('>')
+				i++
+				continue
 			case 'k':
 				b.WriteByte('<')
+				i++
+				continue
 			case 'n':
 				b.WriteByte('\n')
-			default:
-				b.WriteByte(s[i])
+				i++
 				continue
+			case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+				// \NNNN — 4-digit hex Unicode codepoint
+				if i+5 <= len(s) {
+					if cp, err := strconv.ParseInt(s[i+1:i+5], 16, 32); err == nil {
+						b.WriteRune(rune(cp))
+						i += 4
+						continue
+					}
+				}
 			}
-			i++
+			b.WriteByte(s[i])
 			continue
 		}
 		b.WriteByte(s[i])
@@ -522,9 +583,34 @@ func decodeEscape(s string) string {
 	return b.String()
 }
 
+// detectExtensions scans schema for functions/types that require PG extensions.
+func detectExtensions(schema *pgd.Schema) []pgd.Extension {
+	seen := make(map[string]bool)
+	for _, t := range schema.Tables {
+		for _, c := range t.Columns {
+			if strings.Contains(c.Default, "uuid_generate_v") || strings.Contains(c.Default, "gen_random_uuid") {
+				seen["uuid-ossp"] = true
+			}
+		}
+	}
+	var exts []pgd.Extension
+	for name := range seen {
+		exts = append(exts, pgd.Extension{Name: name})
+	}
+	return exts
+}
+
 func isNumeric(t string) bool {
 	t = strings.ToLower(t)
 	return t == "numeric" || t == "decimal"
+}
+
+func isIdentityType(t string) bool {
+	switch strings.ToLower(t) {
+	case "smallint", "integer", "bigint":
+		return true
+	}
+	return false
 }
 
 func indexMethod(m int) string {

--- a/pkg/format/pdd/pdd_test.go
+++ b/pkg/format/pdd/pdd_test.go
@@ -15,9 +15,9 @@ func TestConvert(t *testing.T) {
 		fks     int
 		indexes int
 	}{
-		{"Chinook", "testdata/Chinook.pdd", "testdata/Chinook.pgd", 11, 11, 21},
-		{"AdventureWorks", "testdata/AdventureWorks.pdd", "testdata/AdventureWorks.pgd", 68, 90, 69},
-		{"pagila-light", "testdata/pagila-light.pdd", "testdata/pagila-light.pgd", 15, 22, 32},
+		{"Chinook", "testdata/Chinook.pdd", "testdata/Chinook.pgd", 11, 11, 10},
+		{"AdventureWorks", "testdata/AdventureWorks.pdd", "testdata/AdventureWorks.pgd", 68, 90, 0},
+		{"pagila-light", "testdata/pagila-light.pdd", "testdata/pagila-light.pgd", 15, 22, 17},
 	}
 
 	for _, tt := range tests {

--- a/pkg/format/pdd/testdata/AdventureWorks.pgd
+++ b/pkg/format/pdd/testdata/AdventureWorks.pgd
@@ -8,7 +8,9 @@
   </project>
   <roles></roles>
   <tablespaces></tablespaces>
-  <extensions></extensions>
+  <extensions>
+    <extension name="uuid-ossp"></extension>
+  </extensions>
   <types>
     <domain name="AccountNumber" type="varchar" length="15"></domain>
     <domain name="Flag" type="boolean">
@@ -249,7 +251,7 @@
       <column name="currentflag" type="Flag" nullable="false" default="true" comment="0 = Inactive, 1 = Active"></column>
       <column name="rowguid" type="uuid" nullable="false" default="uuid_generate_v1()"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
-      <column name="organizationnode" type="varchar" default="&#39;/&#39;::character varying" comment="Where the employee is located in corporate hierarchy."></column>
+      <column name="organizationnode" type="varchar" default="&#39;/&#39;" comment="Where the employee is located in corporate hierarchy."></column>
       <pk name="PK_Employee_BusinessEntityID">
         <column name="businessentityid"></column>
       </pk>
@@ -303,12 +305,12 @@
       <check name="CK_EmployeePayHistory_PayFrequency"><![CDATA[payfrequency = ANY (ARRAY[1, 2])]]></check>
       <check name="CK_EmployeePayHistory_Rate"><![CDATA[rate >= 6.50 AND rate <= 200.00]]></check>
     </table>
-    <table name="jobcandidate" comment="R\00E9sum\00E9s submitted to Human Resources by job applicants.">
+    <table name="jobcandidate" comment="Résumés submitted to Human Resources by job applicants.">
       <column name="jobcandidateid" type="integer" nullable="false" comment="Primary key for JobCandidate records.">
         <identity generated="by-default"></identity>
       </column>
       <column name="businessentityid" type="integer" comment="Employee identification number if applicant was hired. Foreign key to Employee.BusinessEntityID."></column>
-      <column name="resume" type="xml" comment="R\00E9sum\00E9 in XML format."></column>
+      <column name="resume" type="xml" comment="Résumé in XML format."></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
       <pk name="PK_JobCandidate_JobCandidateID">
         <column name="jobcandidateid"></column>
@@ -379,7 +381,7 @@
       <column name="document" type="bytea" comment="Complete document."></column>
       <column name="rowguid" type="uuid" nullable="false" default="uuid_generate_v1()" comment="ROWGUIDCOL number uniquely identifying the record. Required for FileStream."></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
-      <column name="documentnode" type="varchar" nullable="false" default="&#39;/&#39;::character varying" comment="Primary key for Document records."></column>
+      <column name="documentnode" type="varchar" nullable="false" default="&#39;/&#39;" comment="Primary key for Document records."></column>
       <pk name="PK_Document_DocumentNode">
         <column name="documentnode"></column>
       </pk>
@@ -510,7 +512,7 @@
     <table name="productdocument" comment="Cross-reference table mapping products to related product documents.">
       <column name="productid" type="integer" nullable="false" comment="Product identification number. Foreign key to Product.ProductID."></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
-      <column name="documentnode" type="varchar" nullable="false" default="&#39;/&#39;::character varying" comment="Document identification number. Foreign key to Document.DocumentNode."></column>
+      <column name="documentnode" type="varchar" nullable="false" default="&#39;/&#39;" comment="Document identification number. Foreign key to Document.DocumentNode."></column>
       <pk name="PK_ProductDocument_ProductID_DocumentNode">
         <column name="productid"></column>
         <column name="documentnode"></column>
@@ -1284,244 +1286,6 @@
         <column name="salespersonid" references="businessentityid"></column>
       </fk>
     </table>
-    <index name="PK_Address_AddressID" table="address" unique="true">
-      <column name="addressid"></column>
-    </index>
-    <index name="PK_AddressType_AddressTypeID" table="addresstype" unique="true">
-      <column name="addresstypeid"></column>
-    </index>
-    <index name="PK_BusinessEntity_BusinessEntityID" table="businessentity" unique="true">
-      <column name="businessentityid"></column>
-    </index>
-    <index name="PK_BusinessEntityAddress_BusinessEntityID_AddressID_AddressType" table="businessentityaddress" unique="true">
-      <column name="businessentityid"></column>
-      <column name="addressid"></column>
-      <column name="addresstypeid"></column>
-    </index>
-    <index name="PK_BusinessEntityContact_BusinessEntityID_PersonID_ContactTypeI" table="businessentitycontact" unique="true">
-      <column name="businessentityid"></column>
-      <column name="personid"></column>
-      <column name="contacttypeid"></column>
-    </index>
-    <index name="PK_ContactType_ContactTypeID" table="contacttype" unique="true">
-      <column name="contacttypeid"></column>
-    </index>
-    <index name="PK_CountryRegion_CountryRegionCode" table="countryregion" unique="true">
-      <column name="countryregioncode"></column>
-    </index>
-    <index name="PK_EmailAddress_BusinessEntityID_EmailAddressID" table="emailaddress" unique="true">
-      <column name="businessentityid"></column>
-      <column name="emailaddressid"></column>
-    </index>
-    <index name="PK_Password_BusinessEntityID" table="password" unique="true">
-      <column name="businessentityid"></column>
-    </index>
-    <index name="PK_Person_BusinessEntityID" table="person" unique="true">
-      <column name="businessentityid"></column>
-    </index>
-    <index name="PK_PersonPhone_BusinessEntityID_PhoneNumber_PhoneNumberTypeID" table="personphone" unique="true">
-      <column name="businessentityid"></column>
-      <column name="phonenumber"></column>
-      <column name="phonenumbertypeid"></column>
-    </index>
-    <index name="PK_PhoneNumberType_PhoneNumberTypeID" table="phonenumbertype" unique="true">
-      <column name="phonenumbertypeid"></column>
-    </index>
-    <index name="PK_StateProvince_StateProvinceID" table="stateprovince" unique="true">
-      <column name="stateprovinceid"></column>
-    </index>
-    <index name="PK_Department_DepartmentID" table="department" unique="true">
-      <column name="departmentid"></column>
-    </index>
-    <index name="PK_Employee_BusinessEntityID" table="employee" unique="true">
-      <column name="businessentityid"></column>
-    </index>
-    <index name="PK_EmployeeDepartmentHistory_BusinessEntityID_StartDate_Departm" table="employeedepartmenthistory" unique="true">
-      <column name="businessentityid"></column>
-      <column name="startdate"></column>
-      <column name="departmentid"></column>
-      <column name="shiftid"></column>
-    </index>
-    <index name="PK_EmployeePayHistory_BusinessEntityID_RateChangeDate" table="employeepayhistory" unique="true">
-      <column name="businessentityid"></column>
-      <column name="ratechangedate"></column>
-    </index>
-    <index name="PK_JobCandidate_JobCandidateID" table="jobcandidate" unique="true">
-      <column name="jobcandidateid"></column>
-    </index>
-    <index name="PK_Shift_ShiftID" table="shift" unique="true">
-      <column name="shiftid"></column>
-    </index>
-    <index name="PK_BillOfMaterials_BillOfMaterialsID" table="billofmaterials" unique="true">
-      <column name="billofmaterialsid"></column>
-    </index>
-    <index name="PK_Culture_CultureID" table="culture" unique="true">
-      <column name="cultureid"></column>
-    </index>
-    <index name="document_rowguid_key" table="document" unique="true">
-      <column name="rowguid"></column>
-    </index>
-    <index name="PK_Document_DocumentNode" table="document" unique="true">
-      <column name="documentnode"></column>
-    </index>
-    <index name="PK_Illustration_IllustrationID" table="illustration" unique="true">
-      <column name="illustrationid"></column>
-    </index>
-    <index name="PK_Location_LocationID" table="location" unique="true">
-      <column name="locationid"></column>
-    </index>
-    <index name="PK_Product_ProductID" table="product" unique="true">
-      <column name="productid"></column>
-    </index>
-    <index name="PK_ProductCategory_ProductCategoryID" table="productcategory" unique="true">
-      <column name="productcategoryid"></column>
-    </index>
-    <index name="PK_ProductCostHistory_ProductID_StartDate" table="productcosthistory" unique="true">
-      <column name="productid"></column>
-      <column name="startdate"></column>
-    </index>
-    <index name="PK_ProductDescription_ProductDescriptionID" table="productdescription" unique="true">
-      <column name="productdescriptionid"></column>
-    </index>
-    <index name="PK_ProductDocument_ProductID_DocumentNode" table="productdocument" unique="true">
-      <column name="productid"></column>
-      <column name="documentnode"></column>
-    </index>
-    <index name="PK_ProductInventory_ProductID_LocationID" table="productinventory" unique="true">
-      <column name="productid"></column>
-      <column name="locationid"></column>
-    </index>
-    <index name="PK_ProductListPriceHistory_ProductID_StartDate" table="productlistpricehistory" unique="true">
-      <column name="productid"></column>
-      <column name="startdate"></column>
-    </index>
-    <index name="PK_ProductModel_ProductModelID" table="productmodel" unique="true">
-      <column name="productmodelid"></column>
-    </index>
-    <index name="PK_ProductModelIllustration_ProductModelID_IllustrationID" table="productmodelillustration" unique="true">
-      <column name="productmodelid"></column>
-      <column name="illustrationid"></column>
-    </index>
-    <index name="PK_ProductModelProductDescriptionCulture_ProductModelID_Product" table="productmodelproductdescriptionculture" unique="true">
-      <column name="productmodelid"></column>
-      <column name="productdescriptionid"></column>
-      <column name="cultureid"></column>
-    </index>
-    <index name="PK_ProductPhoto_ProductPhotoID" table="productphoto" unique="true">
-      <column name="productphotoid"></column>
-    </index>
-    <index name="PK_ProductProductPhoto_ProductID_ProductPhotoID" table="productproductphoto" unique="true">
-      <column name="productid"></column>
-      <column name="productphotoid"></column>
-    </index>
-    <index name="PK_ProductReview_ProductReviewID" table="productreview" unique="true">
-      <column name="productreviewid"></column>
-    </index>
-    <index name="PK_ProductSubcategory_ProductSubcategoryID" table="productsubcategory" unique="true">
-      <column name="productsubcategoryid"></column>
-    </index>
-    <index name="PK_ScrapReason_ScrapReasonID" table="scrapreason" unique="true">
-      <column name="scrapreasonid"></column>
-    </index>
-    <index name="PK_TransactionHistory_TransactionID" table="transactionhistory" unique="true">
-      <column name="transactionid"></column>
-    </index>
-    <index name="PK_TransactionHistoryArchive_TransactionID" table="transactionhistoryarchive" unique="true">
-      <column name="transactionid"></column>
-    </index>
-    <index name="PK_UnitMeasure_UnitMeasureCode" table="unitmeasure" unique="true">
-      <column name="unitmeasurecode"></column>
-    </index>
-    <index name="PK_WorkOrder_WorkOrderID" table="workorder" unique="true">
-      <column name="workorderid"></column>
-    </index>
-    <index name="PK_WorkOrderRouting_WorkOrderID_ProductID_OperationSequence" table="workorderrouting" unique="true">
-      <column name="workorderid"></column>
-      <column name="productid"></column>
-      <column name="operationsequence"></column>
-    </index>
-    <index name="PK_ProductVendor_ProductID_BusinessEntityID" table="productvendor" unique="true">
-      <column name="productid"></column>
-      <column name="businessentityid"></column>
-    </index>
-    <index name="PK_PurchaseOrderDetail_PurchaseOrderID_PurchaseOrderDetailID" table="purchaseorderdetail" unique="true">
-      <column name="purchaseorderid"></column>
-      <column name="purchaseorderdetailid"></column>
-    </index>
-    <index name="PK_PurchaseOrderHeader_PurchaseOrderID" table="purchaseorderheader" unique="true">
-      <column name="purchaseorderid"></column>
-    </index>
-    <index name="PK_ShipMethod_ShipMethodID" table="shipmethod" unique="true">
-      <column name="shipmethodid"></column>
-    </index>
-    <index name="PK_Vendor_BusinessEntityID" table="vendor" unique="true">
-      <column name="businessentityid"></column>
-    </index>
-    <index name="PK_CountryRegionCurrency_CountryRegionCode_CurrencyCode" table="countryregioncurrency" unique="true">
-      <column name="countryregioncode"></column>
-      <column name="currencycode"></column>
-    </index>
-    <index name="PK_CreditCard_CreditCardID" table="creditcard" unique="true">
-      <column name="creditcardid"></column>
-    </index>
-    <index name="PK_Currency_CurrencyCode" table="currency" unique="true">
-      <column name="currencycode"></column>
-    </index>
-    <index name="PK_CurrencyRate_CurrencyRateID" table="currencyrate" unique="true">
-      <column name="currencyrateid"></column>
-    </index>
-    <index name="PK_Customer_CustomerID" table="customer" unique="true">
-      <column name="customerid"></column>
-    </index>
-    <index name="PK_PersonCreditCard_BusinessEntityID_CreditCardID" table="personcreditcard" unique="true">
-      <column name="businessentityid"></column>
-      <column name="creditcardid"></column>
-    </index>
-    <index name="PK_SalesOrderDetail_SalesOrderID_SalesOrderDetailID" table="salesorderdetail" unique="true">
-      <column name="salesorderid"></column>
-      <column name="salesorderdetailid"></column>
-    </index>
-    <index name="PK_SalesOrderHeader_SalesOrderID" table="salesorderheader" unique="true">
-      <column name="salesorderid"></column>
-    </index>
-    <index name="PK_SalesOrderHeaderSalesReason_SalesOrderID_SalesReasonID" table="salesorderheadersalesreason" unique="true">
-      <column name="salesorderid"></column>
-      <column name="salesreasonid"></column>
-    </index>
-    <index name="PK_SalesPerson_BusinessEntityID" table="salesperson" unique="true">
-      <column name="businessentityid"></column>
-    </index>
-    <index name="PK_SalesPersonQuotaHistory_BusinessEntityID_QuotaDate" table="salespersonquotahistory" unique="true">
-      <column name="businessentityid"></column>
-      <column name="quotadate"></column>
-    </index>
-    <index name="PK_SalesReason_SalesReasonID" table="salesreason" unique="true">
-      <column name="salesreasonid"></column>
-    </index>
-    <index name="PK_SalesTaxRate_SalesTaxRateID" table="salestaxrate" unique="true">
-      <column name="salestaxrateid"></column>
-    </index>
-    <index name="PK_SalesTerritory_TerritoryID" table="salesterritory" unique="true">
-      <column name="territoryid"></column>
-    </index>
-    <index name="PK_SalesTerritoryHistory_BusinessEntityID_StartDate_TerritoryID" table="salesterritoryhistory" unique="true">
-      <column name="businessentityid"></column>
-      <column name="startdate"></column>
-      <column name="territoryid"></column>
-    </index>
-    <index name="PK_ShoppingCartItem_ShoppingCartItemID" table="shoppingcartitem" unique="true">
-      <column name="shoppingcartitemid"></column>
-    </index>
-    <index name="PK_SpecialOffer_SpecialOfferID" table="specialoffer" unique="true">
-      <column name="specialofferid"></column>
-    </index>
-    <index name="PK_SpecialOfferProduct_SpecialOfferID_ProductID" table="specialofferproduct" unique="true">
-      <column name="specialofferid"></column>
-      <column name="productid"></column>
-    </index>
-    <index name="PK_Store_BusinessEntityID" table="store" unique="true">
-      <column name="businessentityid"></column>
-    </index>
   </schema>
   <functions></functions>
   <triggers></triggers>

--- a/pkg/format/pdd/testdata/Chinook.pgd
+++ b/pkg/format/pdd/testdata/Chinook.pgd
@@ -164,38 +164,17 @@
         <column name="MediaTypeId" references="MediaTypeId"></column>
       </fk>
     </table>
-    <index name="PK_Album" table="Album" unique="true">
-      <column name="AlbumId"></column>
-    </index>
     <index name="IFK_AlbumArtistId" table="Album">
       <column name="ArtistId"></column>
-    </index>
-    <index name="PK_Artist" table="Artist" unique="true">
-      <column name="ArtistId"></column>
-    </index>
-    <index name="PK_Customer" table="Customer" unique="true">
-      <column name="CustomerId"></column>
     </index>
     <index name="IFK_CustomerSupportRepId" table="Customer">
       <column name="SupportRepId"></column>
     </index>
-    <index name="PK_Employee" table="Employee" unique="true">
-      <column name="EmployeeId"></column>
-    </index>
     <index name="IFK_EmployeeReportsTo" table="Employee">
       <column name="ReportsTo"></column>
     </index>
-    <index name="PK_Genre" table="Genre" unique="true">
-      <column name="GenreId"></column>
-    </index>
-    <index name="PK_Invoice" table="Invoice" unique="true">
-      <column name="InvoiceId"></column>
-    </index>
     <index name="IFK_InvoiceCustomerId" table="Invoice">
       <column name="CustomerId"></column>
-    </index>
-    <index name="PK_InvoiceLine" table="InvoiceLine" unique="true">
-      <column name="InvoiceLineId"></column>
     </index>
     <index name="IFK_InvoiceLineInvoiceId" table="InvoiceLine">
       <column name="InvoiceId"></column>
@@ -203,20 +182,7 @@
     <index name="IFK_InvoiceLineTrackId" table="InvoiceLine">
       <column name="TrackId"></column>
     </index>
-    <index name="PK_MediaType" table="MediaType" unique="true">
-      <column name="MediaTypeId"></column>
-    </index>
-    <index name="PK_Playlist" table="Playlist" unique="true">
-      <column name="PlaylistId"></column>
-    </index>
-    <index name="PK_PlaylistTrack" table="PlaylistTrack" unique="true">
-      <column name="PlaylistId"></column>
-      <column name="TrackId"></column>
-    </index>
     <index name="IFK_PlaylistTrackTrackId" table="PlaylistTrack">
-      <column name="TrackId"></column>
-    </index>
-    <index name="PK_Track" table="Track" unique="true">
       <column name="TrackId"></column>
     </index>
     <index name="IFK_TrackAlbumId" table="Track">

--- a/pkg/format/pdd/testdata/pagila-light.pgd
+++ b/pkg/format/pdd/testdata/pagila-light.pgd
@@ -10,6 +10,13 @@
   <tablespaces></tablespaces>
   <extensions></extensions>
   <types>
+    <enum name="mpaa_rating" schema="public">
+      <label>G</label>
+      <label>PG</label>
+      <label>PG-13</label>
+      <label>R</label>
+      <label>NC-17</label>
+    </enum>
     <domain name="year" type="integer"></domain>
   </types>
   <sequences></sequences>
@@ -75,7 +82,7 @@
       <column name="email" type="varchar" length="50"></column>
       <column name="address_id" type="smallint" nullable="false"></column>
       <column name="activebool" type="boolean" nullable="false" default="true"></column>
-      <column name="create_date" type="date" nullable="false" default="(&#39;now&#39;::text)::date"></column>
+      <column name="create_date" type="date" nullable="false" default="(&#39;now&#39;::text)"></column>
       <column name="last_update" type="timestamp" default="now()"></column>
       <column name="active" type="integer"></column>
       <pk name="customer_pkey">
@@ -99,7 +106,7 @@
       <column name="rental_rate" type="numeric" precision="4" scale="2" nullable="false" default="4.99"></column>
       <column name="length" type="smallint"></column>
       <column name="replacement_cost" type="numeric" precision="5" scale="2" nullable="false" default="19.99"></column>
-      <column name="rating" type="mpaa_rating" default="&#39;G&#39;::mpaa_rating"></column>
+      <column name="rating" type="mpaa_rating" default="&#39;G&#39;"></column>
       <column name="last_update" type="timestamp" nullable="false" default="now()"></column>
       <column name="special_features" type="text[]"></column>
       <column name="fulltext" type="tsvector" nullable="false"></column>
@@ -247,25 +254,10 @@
     <index name="idx_actor_last_name" table="actor">
       <column name="last_name"></column>
     </index>
-    <index name="actor_pkey_idx_pk" table="actor" unique="true">
-      <column name="actor_id"></column>
-    </index>
     <index name="idx_fk_city_id" table="address">
       <column name="city_id"></column>
     </index>
-    <index name="address_pkey_idx_pk" table="address" unique="true">
-      <column name="address_id"></column>
-    </index>
-    <index name="category_pkey_idx_pk" table="category" unique="true">
-      <column name="category_id"></column>
-    </index>
     <index name="idx_fk_country_id" table="city">
-      <column name="country_id"></column>
-    </index>
-    <index name="city_pkey_idx_pk" table="city" unique="true">
-      <column name="city_id"></column>
-    </index>
-    <index name="country_pkey_idx_pk" table="country" unique="true">
       <column name="country_id"></column>
     </index>
     <index name="idx_fk_address_id" table="customer">
@@ -276,9 +268,6 @@
     </index>
     <index name="idx_last_name" table="customer">
       <column name="last_name"></column>
-    </index>
-    <index name="customer_pkey_idx_pk" table="customer" unique="true">
-      <column name="customer_id"></column>
     </index>
     <index name="film_fulltext_idx" table="film" using="gist">
       <column name="fulltext"></column>
@@ -292,38 +281,18 @@
     <index name="idx_title" table="film">
       <column name="title"></column>
     </index>
-    <index name="film_pkey_idx_pk" table="film" unique="true">
-      <column name="film_id"></column>
-    </index>
     <index name="idx_fk_film_id" table="film_actor">
       <column name="film_id"></column>
-    </index>
-    <index name="film_actor_pkey_idx_pk" table="film_actor" unique="true">
-      <column name="actor_id"></column>
-      <column name="film_id"></column>
-    </index>
-    <index name="film_category_pkey_idx_pk" table="film_category" unique="true">
-      <column name="film_id"></column>
-      <column name="category_id"></column>
     </index>
     <index name="idx_store_id_film_id" table="inventory">
       <column name="store_id"></column>
       <column name="film_id"></column>
-    </index>
-    <index name="inventory_pkey_idx_pk" table="inventory" unique="true">
-      <column name="inventory_id"></column>
-    </index>
-    <index name="language_pkey_idx_pk" table="language" unique="true">
-      <column name="language_id"></column>
     </index>
     <index name="idx_fk_customer_id" table="payment">
       <column name="customer_id"></column>
     </index>
     <index name="idx_fk_staff_id" table="payment">
       <column name="staff_id"></column>
-    </index>
-    <index name="payment_pkey_idx_pk" table="payment" unique="true">
-      <column name="payment_id"></column>
     </index>
     <index name="idx_fk_inventory_id" table="rental">
       <column name="inventory_id"></column>
@@ -333,17 +302,8 @@
       <column name="inventory_id"></column>
       <column name="customer_id"></column>
     </index>
-    <index name="rental_pkey_idx_pk" table="rental" unique="true">
-      <column name="rental_id"></column>
-    </index>
-    <index name="staff_pkey_idx_pk" table="staff" unique="true">
-      <column name="staff_id"></column>
-    </index>
     <index name="idx_unq_manager_staff_id" table="store" unique="true">
       <column name="manager_staff_id"></column>
-    </index>
-    <index name="store_pkey_idx_pk" table="store" unique="true">
-      <column name="store_id"></column>
     </index>
   </schema>
   <functions></functions>

--- a/pkg/format/pgre/convert.go
+++ b/pkg/format/pgre/convert.go
@@ -1,8 +1,12 @@
 package pgre
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
+
+	pg "github.com/pganalyze/pg_query_go/v6"
+	pgquery "github.com/wasilibs/go-pgquery"
 
 	"github.com/vmkteam/pgdesigner/pkg/pgd"
 )
@@ -44,19 +48,23 @@ func (i *introspector) convertTable(pt pgTable) (*pgd.Table, []pgd.Index, error)
 				Columns: pgd.ColRefsFromNames(i.queryColumnNames(pt.OID, c.ConKey)),
 			}
 		case "u": // UNIQUE
-			t.Uniques = append(t.Uniques, pgd.Unique{
+			u := pgd.Unique{
 				Name:    c.Name,
 				Columns: pgd.ColRefsFromNames(i.queryColumnNames(pt.OID, c.ConKey)),
-			})
+			}
+			if strings.Contains(c.Def, "NULLS NOT DISTINCT") {
+				u.NullsDistinct = "false"
+			}
+			t.Uniques = append(t.Uniques, u)
 		case "c": // CHECK
 			t.Checks = append(t.Checks, pgd.Check{
 				Name:       c.Name,
 				Expression: c.CheckExpr,
 			})
 		case "x": // EXCLUDE
-			t.Excludes = append(t.Excludes, pgd.Exclude{
-				Name: c.Name,
-			})
+			if ex := parseExcludeConstraintDef(c.Name, c.Def); ex != nil {
+				t.Excludes = append(t.Excludes, *ex)
+			}
 		case "f": // FK
 			refSchema, refTable := i.queryRefTableName(c.ConfRelID)
 			toTable := refTable
@@ -108,7 +116,7 @@ func convertColumn(c pgColumn) pgd.Column {
 
 	// Parse length/precision from format_type output
 	if l, p, s := parseTypeMods(c.Type); l > 0 || p > 0 {
-		if pgd.NeedsLength(col.Type) {
+		if pgd.NeedsLength(strings.TrimSuffix(col.Type, "[]")) {
 			col.Length = l
 		} else {
 			col.Precision = p
@@ -259,50 +267,203 @@ func convertIndex(tableName string, idx pgIndex) *pgd.Index {
 		out.Where = &pgd.WhereClause{Value: idx.Predicate}
 	}
 
-	// Parse columns from index definition
-	cols := parseIndexColumns(idx.Def)
-	for _, c := range cols {
-		if pgd.IsExpression(c) {
-			out.Expressions = append(out.Expressions, pgd.Expression{Value: c})
+	// Parse columns and WITH params from index definition
+	def, withParams := splitIndexWith(idx.Def)
+	if len(withParams) > 0 {
+		out.With = &pgd.With{Params: withParams}
+	}
+	for _, elem := range parseIndexColumns(def) {
+		if pgd.IsExpression(elem.Name) {
+			out.Expressions = append(out.Expressions, pgd.Expression{Value: elem.Name})
 		} else {
-			out.Columns = append(out.Columns, pgd.ColRef{Name: strings.Trim(c, `"`)})
+			elem.Name = strings.Trim(elem.Name, `"`)
+			out.Columns = append(out.Columns, elem)
 		}
 	}
 
 	return out
 }
 
-// parseIndexColumns extracts column names from pg_get_indexdef output.
-// "CREATE INDEX idx ON public.table USING btree (col1, col2)" → ["col1", "col2"]
-func parseIndexColumns(def string) []string {
-	// Find content between last ( and last )
-	start := strings.LastIndex(def, "(")
-	end := strings.LastIndex(def, ")")
-	if start < 0 || end < 0 || end <= start {
+// parseExcludeConstraintDef parses pg_get_constraintdef output for EXCLUDE constraints
+// using pg_query to get correct AST parsing of expressions and WHERE clauses.
+func parseExcludeConstraintDef(name, def string) *pgd.Exclude {
+	// Wrap in ALTER TABLE to make it parseable
+	sql := fmt.Sprintf(`ALTER TABLE "t" ADD CONSTRAINT %q %s;`, name, def)
+	tree, err := pgquery.Parse(sql)
+	if err != nil || len(tree.Stmts) == 0 {
+		return &pgd.Exclude{Name: name}
+	}
+	alter := tree.Stmts[0].Stmt.GetAlterTableStmt()
+	if alter == nil || len(alter.Cmds) == 0 {
+		return &pgd.Exclude{Name: name}
+	}
+	cmd := alter.Cmds[0].GetAlterTableCmd()
+	if cmd == nil || cmd.Def == nil {
+		return &pgd.Exclude{Name: name}
+	}
+	con := cmd.Def.GetConstraint()
+	if con == nil {
+		return &pgd.Exclude{Name: name}
+	}
+
+	ex := pgd.Exclude{
+		Name:  name,
+		Using: con.AccessMethod,
+	}
+	for _, node := range con.Exclusions {
+		list := node.GetList()
+		if list == nil || len(list.Items) < 2 {
+			continue
+		}
+		var elem pgd.ExcludeElement
+		if ie := list.Items[0].GetIndexElem(); ie != nil {
+			if ie.Name != "" {
+				elem.Column = ie.Name
+			} else if ie.Expr != nil {
+				elem.Expression = nodeToSQL(ie.Expr)
+			}
+		}
+		if opList := list.Items[1].GetList(); opList != nil {
+			for _, op := range opList.Items {
+				if s := op.GetString_(); s != nil {
+					elem.With = s.Sval
+				}
+			}
+		}
+		ex.Elements = append(ex.Elements, elem)
+	}
+	if con.WhereClause != nil {
+		ex.Where = &pgd.WhereClause{Value: nodeToSQL(con.WhereClause)}
+	}
+	return &ex
+}
+
+// nodeToSQL deparses a pg_query node back to SQL text.
+func nodeToSQL(n *pg.Node) string {
+	tree := &pg.ParseResult{
+		Stmts: []*pg.RawStmt{{
+			Stmt: &pg.Node{Node: &pg.Node_SelectStmt{
+				SelectStmt: &pg.SelectStmt{
+					TargetList: []*pg.Node{{
+						Node: &pg.Node_ResTarget{
+							ResTarget: &pg.ResTarget{Val: n},
+						},
+					}},
+				},
+			}},
+		}},
+	}
+	result, err := pgquery.Deparse(tree)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimPrefix(result, "SELECT ")
+}
+
+// splitIndexWith splits pg_get_indexdef output into the index definition (without WITH)
+// and extracted storage parameters. e.g. "CREATE INDEX ... (...) WITH (fastupdate='true')"
+// → "CREATE INDEX ... (...)", [{fastupdate, true}]
+func splitIndexWith(def string) (string, []pgd.WithParam) {
+	idx := strings.Index(strings.ToUpper(def), ") WITH (")
+	if idx < 0 {
+		return def, nil
+	}
+	withStart := idx + len(") WITH (")
+	withEnd := strings.Index(def[withStart:], ")")
+	if withEnd < 0 {
+		return def, nil
+	}
+	withStr := def[withStart : withStart+withEnd]
+	rest := def[withStart+withEnd+1:]
+
+	var params []pgd.WithParam
+	for _, p := range strings.Split(withStr, ",") {
+		p = strings.TrimSpace(p)
+		if eq := strings.IndexByte(p, '='); eq > 0 {
+			params = append(params, pgd.WithParam{
+				Name:  strings.TrimSpace(p[:eq]),
+				Value: strings.Trim(strings.TrimSpace(p[eq+1:]), "'"),
+			})
+		}
+	}
+
+	return def[:idx+1] + rest, params
+}
+
+// parseIndexColumns extracts columns with sort direction from pg_get_indexdef output.
+func parseIndexColumns(def string) []pgd.ColRef {
+	onIdx := strings.Index(strings.ToUpper(def), " ON ")
+	if onIdx < 0 {
 		return nil
 	}
-
-	inner := def[start+1 : end]
-	// Remove WHERE clause if present
-	if idx := strings.Index(strings.ToUpper(inner), " WHERE "); idx > 0 {
-		inner = inner[:idx]
+	start := strings.IndexByte(def[onIdx:], '(')
+	if start < 0 {
+		return nil
 	}
+	start += onIdx
+	depth := 1
+	end := start + 1
+	for end < len(def) && depth > 0 {
+		switch def[end] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+		end++
+	}
+	if depth != 0 {
+		return nil
+	}
+	inner := def[start+1 : end-1]
 
-	parts := strings.Split(inner, ",")
-	var cols []string
+	parts := splitTopLevel(inner, ',')
+	var cols []pgd.ColRef
 	for _, p := range parts {
 		col := strings.TrimSpace(p)
-		// Remove sort direction
-		col = strings.TrimSuffix(col, " ASC")
-		col = strings.TrimSuffix(col, " DESC")
-		col = strings.TrimSuffix(col, " NULLS FIRST")
-		col = strings.TrimSuffix(col, " NULLS LAST")
+		var ref pgd.ColRef
+		if strings.HasSuffix(col, " NULLS FIRST") {
+			ref.Nulls = "first"
+			col = strings.TrimSuffix(col, " NULLS FIRST")
+		} else if strings.HasSuffix(col, " NULLS LAST") {
+			ref.Nulls = "last"
+			col = strings.TrimSuffix(col, " NULLS LAST")
+		}
+		if strings.HasSuffix(col, " DESC") {
+			ref.Order = "desc"
+			col = strings.TrimSuffix(col, " DESC")
+		} else {
+			col = strings.TrimSuffix(col, " ASC")
+		}
 		col = strings.TrimSpace(col)
 		if col != "" {
-			cols = append(cols, col)
+			ref.Name = col
+			cols = append(cols, ref)
 		}
 	}
 	return cols
+}
+
+// splitTopLevel splits a string by sep, but only at the top level (not inside parentheses).
+func splitTopLevel(s string, sep byte) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i := range len(s) {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case sep:
+			if depth == 0 {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
 }
 
 func convertSequence(s pgSequence) pgd.Sequence {

--- a/pkg/format/pgre/introspect.go
+++ b/pkg/format/pgre/introspect.go
@@ -111,7 +111,7 @@ type pgSequence struct {
 type pgEnum struct {
 	Name   string
 	Schema string
-	Labels []string
+	Labels []string `pg:",array"`
 }
 
 type pgDomain struct {
@@ -191,8 +191,8 @@ func (i *introspector) introspect() (*pgd.Project, error) {
 
 	// Full mode: views, functions, triggers, extensions, domains, enums
 	if i.opts.Full {
-		if intErr := i.introspectFull(project); intErr != nil { //nolint:govet
-			return nil, err
+		if fullErr := i.introspectFull(project); fullErr != nil {
+			return nil, fullErr
 		}
 	}
 
@@ -547,6 +547,7 @@ func (i *introspector) queryFunctions() ([]pgFunction, error) {
 		JOIN pg_namespace n ON n.oid = p.pronamespace
 		JOIN pg_language l ON l.oid = p.prolang
 		WHERE p.prokind IN ('f', 'p')
+		  AND NOT EXISTS (SELECT 1 FROM pg_depend d WHERE d.objid = p.oid AND d.deptype = 'e')
 		  %s
 		ORDER BY n.nspname, p.proname
 	`, i.schemaFilter()))

--- a/pkg/format/sql/sql.go
+++ b/pkg/format/sql/sql.go
@@ -409,10 +409,14 @@ func extractColumnConstraints(tbl *pgd.Table, col *pg.ColumnDef) {
 				Columns: []pgd.ColRef{{Name: col.Colname}},
 			}
 		case pg.ConstrType_CONSTR_UNIQUE:
-			tbl.Uniques = append(tbl.Uniques, pgd.Unique{
+			u := pgd.Unique{
 				Name:    con.Constraint.Conname,
 				Columns: []pgd.ColRef{{Name: col.Colname}},
-			})
+			}
+			if con.Constraint.NullsNotDistinct {
+				u.NullsDistinct = "false"
+			}
+			tbl.Uniques = append(tbl.Uniques, u)
 		case pg.ConstrType_CONSTR_FOREIGN:
 			fk := convertFKConstraint(con.Constraint)
 			if len(fk.Columns) == 0 {
@@ -461,7 +465,7 @@ func convertColumnDef(col *pg.ColumnDef) pgd.Column {
 			c.Nullable = "false"
 		case pg.ConstrType_CONSTR_DEFAULT:
 			if con.Constraint.RawExpr != nil {
-				c.Default = nodeToSQL(con.Constraint.RawExpr)
+				c.Default = stripDefaultTypeCast(nodeToSQL(con.Constraint.RawExpr), c.Type)
 			}
 		case pg.ConstrType_CONSTR_IDENTITY:
 			gen := "by-default"
@@ -509,7 +513,7 @@ func applyTypeMods(c *pgd.Column, tn *pg.TypeName) {
 		return
 	}
 
-	typeLower := strings.ToLower(c.Type)
+	typeLower := strings.TrimSuffix(strings.ToLower(c.Type), "[]")
 
 	switch {
 	case pgd.NeedsLength(typeLower):
@@ -543,6 +547,9 @@ func convertTableConstraint(tbl *pgd.Table, con *pg.Constraint) {
 
 	case pg.ConstrType_CONSTR_UNIQUE:
 		u := pgd.Unique{Name: con.Conname}
+		if con.NullsNotDistinct {
+			u.NullsDistinct = "false"
+		}
 		for _, k := range con.Keys {
 			if s, ok := k.Node.(*pg.Node_String_); ok {
 				u.Columns = append(u.Columns, pgd.ColRef{Name: s.String_.Sval})
@@ -560,7 +567,66 @@ func convertTableConstraint(tbl *pgd.Table, con *pg.Constraint) {
 	case pg.ConstrType_CONSTR_FOREIGN:
 		fk := convertFKConstraint(con)
 		tbl.FKs = append(tbl.FKs, fk)
+
+	case pg.ConstrType_CONSTR_EXCLUSION:
+		tbl.Excludes = append(tbl.Excludes, convertExcludeConstraint(con))
 	}
+}
+
+// convertExcludeConstraint converts a pg EXCLUDE constraint to pgd.Exclude.
+func convertExcludeConstraint(con *pg.Constraint) pgd.Exclude {
+	ex := pgd.Exclude{
+		Name:  con.Conname,
+		Using: con.AccessMethod,
+	}
+	for _, node := range con.Exclusions {
+		list := node.GetList()
+		if list == nil || len(list.Items) < 2 {
+			continue
+		}
+		var elem pgd.ExcludeElement
+		// first item: IndexElem (column or expression)
+		if ie := list.Items[0].GetIndexElem(); ie != nil {
+			if ie.Name != "" {
+				elem.Column = ie.Name
+			} else if ie.Expr != nil {
+				elem.Expression = nodeToSQL(ie.Expr)
+			}
+		}
+		// second item: operator name list
+		if opList := list.Items[1].GetList(); opList != nil {
+			for _, op := range opList.Items {
+				if s := op.GetString_(); s != nil {
+					elem.With = s.Sval
+				}
+			}
+		}
+		ex.Elements = append(ex.Elements, elem)
+	}
+	if con.WhereClause != nil {
+		ex.Where = &pgd.WhereClause{Value: stripLiteralTypeCasts(nodeToSQL(con.WhereClause))}
+	}
+	return ex
+}
+
+func parseWithParams(options []*pg.Node) []pgd.WithParam {
+	var params []pgd.WithParam
+	for _, opt := range options {
+		de := opt.GetDefElem()
+		if de == nil || de.Arg == nil {
+			continue
+		}
+		var val string
+		if s := de.Arg.GetString_(); s != nil {
+			val = s.Sval
+		} else if iv := de.Arg.GetInteger(); iv != nil {
+			val = strconv.FormatInt(int64(iv.Ival), 10)
+		}
+		if val != "" {
+			params = append(params, pgd.WithParam{Name: de.Defname, Value: val})
+		}
+	}
+	return params
 }
 
 // CREATE INDEX
@@ -609,8 +675,12 @@ func (c *sqlConverter) convertCreateIndex(stmt *pg.IndexStmt) { //nolint:gocogni
 		}
 	}
 
+	if params := parseWithParams(stmt.Options); len(params) > 0 {
+		idx.With = &pgd.With{Params: params}
+	}
+
 	if stmt.WhereClause != nil {
-		idx.Where = &pgd.WhereClause{Value: nodeToSQL(stmt.WhereClause)}
+		idx.Where = &pgd.WhereClause{Value: stripLiteralTypeCasts(nodeToSQL(stmt.WhereClause))}
 	}
 
 	schema.Indexes = append(schema.Indexes, idx)
@@ -690,6 +760,9 @@ func (c *sqlConverter) convertAlterTable(stmt *pg.AlterTableStmt) { //nolint:goc
 			schema.Tables[tableIdx].PK = &pk
 		case pg.ConstrType_CONSTR_UNIQUE:
 			u := pgd.Unique{Name: con.Constraint.Conname}
+			if con.Constraint.NullsNotDistinct {
+				u.NullsDistinct = "false"
+			}
 			for _, k := range con.Constraint.Keys {
 				if s, ok := k.Node.(*pg.Node_String_); ok {
 					u.Columns = append(u.Columns, pgd.ColRef{Name: s.String_.Sval})
@@ -702,6 +775,8 @@ func (c *sqlConverter) convertAlterTable(stmt *pg.AlterTableStmt) { //nolint:goc
 				ch.Expression = nodeToSQL(con.Constraint.RawExpr)
 			}
 			schema.Tables[tableIdx].Checks = append(schema.Tables[tableIdx].Checks, ch)
+		case pg.ConstrType_CONSTR_EXCLUSION:
+			schema.Tables[tableIdx].Excludes = append(schema.Tables[tableIdx].Excludes, convertExcludeConstraint(con.Constraint))
 		}
 	}
 }
@@ -1035,6 +1110,15 @@ func (c *sqlConverter) convertComment(stmt *pg.CommentStmt) {
 			}
 		case *pg.Node_String_:
 			cm.Name = obj.String_.Sval
+		case *pg.Node_TypeName:
+			names := extractStrings(obj.TypeName.Names)
+			switch len(names) {
+			case 1:
+				cm.Name = names[0]
+			case 2:
+				cm.Schema = names[0]
+				cm.Name = names[1]
+			}
 		case *pg.Node_ObjectWithArgs:
 			names := extractStrings(obj.ObjectWithArgs.Objname)
 			switch len(names) {
@@ -1208,6 +1292,120 @@ func nodeToSQL(n *pg.Node) string {
 	}
 	result = strings.TrimPrefix(result, "SELECT ")
 	return cleanOperators(result)
+}
+
+// stripDefaultTypeCast removes redundant type casts from default values.
+// pg_dump normalizes `DEFAULT ”` to `DEFAULT ”::text` — strip the cast when it matches the column type.
+func stripDefaultTypeCast(def, colType string) string {
+	idx := strings.LastIndex(def, "::")
+	if idx <= 0 {
+		return def
+	}
+	valuePart := def[:idx]
+	if len(valuePart) == 0 {
+		return def
+	}
+	if normalizeTypeName(colType) == normalizeTypeName(def[idx+2:]) {
+		return valuePart
+	}
+	return def
+}
+
+// normalizeTypeName maps PG type aliases to canonical forms for comparison.
+func normalizeTypeName(t string) string {
+	t = strings.TrimSpace(strings.ToLower(t))
+	// handle array suffix
+	arraySuffix := ""
+	if strings.HasSuffix(t, "[]") {
+		arraySuffix = "[]"
+		t = strings.TrimSuffix(t, "[]")
+	}
+	switch t {
+	case "int", "int4", "integer":
+		t = "integer"
+	case "int8", "bigint":
+		t = "bigint"
+	case "int2", "smallint":
+		t = "smallint"
+	case "float4", "real":
+		t = "real"
+	case "float8", "double precision":
+		t = "double precision"
+	case "bool", "boolean":
+		t = "boolean"
+	case "varchar", "character varying":
+		t = "varchar"
+	case "char", "character":
+		t = "char"
+	case "timestamptz", "timestamp with time zone":
+		t = "timestamptz"
+	case "timestamp", "timestamp without time zone":
+		t = "timestamp"
+	case "timetz", "time with time zone":
+		t = "timetz"
+	case "time", "time without time zone":
+		t = "time"
+	}
+	return t + arraySuffix
+}
+
+// stripLiteralTypeCasts removes type casts from string literals in SQL expressions.
+// pg_dump adds explicit casts like ”::text or '{}'::jsonb — strip them for stable round-trip.
+func stripLiteralTypeCasts(expr string) string {
+	var b strings.Builder
+	b.Grow(len(expr))
+	i := 0
+	for i < len(expr) {
+		// find next single-quoted literal
+		q := strings.Index(expr[i:], "'")
+		if q < 0 {
+			b.WriteString(expr[i:])
+			break
+		}
+		// write everything before the quote
+		b.WriteString(expr[i : i+q])
+		// find closing quote (handle '' escapes)
+		start := i + q
+		j := start + 1
+		for j < len(expr) {
+			if expr[j] == '\'' {
+				if j+1 < len(expr) && expr[j+1] == '\'' {
+					j += 2 // escaped quote
+					continue
+				}
+				break // closing quote
+			}
+			j++
+		}
+		if j >= len(expr) {
+			b.WriteString(expr[start:])
+			break
+		}
+		literal := expr[start : j+1] // 'value' including quotes
+		rest := expr[j+1:]
+		// check for ::type immediately after closing quote
+		if strings.HasPrefix(rest, "::") {
+			// find end of type name (letters, digits, _, [], spaces for "character varying" etc.)
+			k := 2
+			for k < len(rest) {
+				ch := rest[k]
+				if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '[' || ch == ']' || ch == ' ' {
+					k++
+				} else {
+					break
+				}
+			}
+			typeName := strings.TrimRight(rest[2:k], " ")
+			if typeName != "" {
+				b.WriteString(literal)
+				i = j + 1 + k
+				continue
+			}
+		}
+		b.WriteString(literal)
+		i = j + 1
+	}
+	return b.String()
 }
 
 // cleanOperators removes schema-qualified operator syntax that pg_query deparse produces.

--- a/pkg/format/sql/testdata/adventureworks.pgd
+++ b/pkg/format/sql/testdata/adventureworks.pgd
@@ -79,8 +79,8 @@
       <column name="loginid" type="varchar" length="256" nullable="false"></column>
       <column name="jobtitle" type="varchar" length="50" nullable="false"></column>
       <column name="birthdate" type="date" nullable="false"></column>
-      <column name="maritalstatus" type="bpchar" nullable="false"></column>
-      <column name="gender" type="bpchar" nullable="false"></column>
+      <column name="maritalstatus" type="char" length="1" nullable="false"></column>
+      <column name="gender" type="char" length="1" nullable="false"></column>
       <column name="hiredate" type="date" nullable="false"></column>
       <column name="salariedflag" type="Flag" nullable="false" default="true"></column>
       <column name="vacationhours" type="smallint" nullable="false" default="0"></column>
@@ -88,7 +88,7 @@
       <column name="currentflag" type="Flag" nullable="false" default="true"></column>
       <column name="rowguid" type="uuid" nullable="false" default="public.uuid_generate_v1()"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
-      <column name="organizationnode" type="varchar" default="&#39;/&#39;::varchar"></column>
+      <column name="organizationnode" type="varchar" default="&#39;/&#39;"></column>
       <pk name="PK_Employee_BusinessEntityID">
         <column name="businessentityid"></column>
       </pk>
@@ -288,7 +288,7 @@
     </table>
     <table name="person">
       <column name="businessentityid" type="integer" nullable="false"></column>
-      <column name="persontype" type="bpchar" nullable="false"></column>
+      <column name="persontype" type="char" length="2" nullable="false"></column>
       <column name="namestyle" type="NameStyle" nullable="false" default="false"></column>
       <column name="title" type="varchar" length="8"></column>
       <column name="firstname" type="Name" nullable="false"></column>
@@ -336,7 +336,7 @@
     </table>
     <table name="stateprovince">
       <column name="stateprovinceid" type="integer" nullable="false"></column>
-      <column name="stateprovincecode" type="bpchar" nullable="false"></column>
+      <column name="stateprovincecode" type="char" length="3" nullable="false"></column>
       <column name="countryregioncode" type="varchar" length="3" nullable="false"></column>
       <column name="isonlystateprovinceflag" type="Flag" nullable="false" default="true"></column>
       <column name="name" type="Name" nullable="false"></column>
@@ -366,7 +366,7 @@
       <column name="componentid" type="integer" nullable="false"></column>
       <column name="startdate" type="timestamp" nullable="false" default="now()"></column>
       <column name="enddate" type="timestamp"></column>
-      <column name="unitmeasurecode" type="bpchar" nullable="false"></column>
+      <column name="unitmeasurecode" type="char" length="3" nullable="false"></column>
       <column name="bomlevel" type="smallint" nullable="false"></column>
       <column name="perassemblyqty" type="numeric" precision="8" scale="2" nullable="false" default="1.00"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
@@ -388,7 +388,7 @@
       <check name="CK_BillOfMaterials_ProductAssemblyID"><![CDATA[productassemblyid <> componentid]]></check>
     </table>
     <table name="culture">
-      <column name="cultureid" type="bpchar" nullable="false"></column>
+      <column name="cultureid" type="char" length="6" nullable="false"></column>
       <column name="name" type="Name" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
       <pk name="PK_Culture_CultureID">
@@ -401,14 +401,14 @@
       <column name="folderflag" type="Flag" nullable="false" default="false"></column>
       <column name="filename" type="varchar" length="400" nullable="false"></column>
       <column name="fileextension" type="varchar" length="8"></column>
-      <column name="revision" type="bpchar" nullable="false"></column>
+      <column name="revision" type="char" length="5" nullable="false"></column>
       <column name="changenumber" type="integer" nullable="false" default="0"></column>
       <column name="status" type="smallint" nullable="false"></column>
       <column name="documentsummary" type="text"></column>
       <column name="document" type="bytea"></column>
       <column name="rowguid" type="uuid" nullable="false" default="public.uuid_generate_v1()"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
-      <column name="documentnode" type="varchar" nullable="false" default="&#39;/&#39;::varchar"></column>
+      <column name="documentnode" type="varchar" nullable="false" default="&#39;/&#39;"></column>
       <pk name="PK_Document_DocumentNode">
         <column name="documentnode"></column>
       </pk>
@@ -452,13 +452,13 @@
       <column name="standardcost" type="numeric" nullable="false"></column>
       <column name="listprice" type="numeric" nullable="false"></column>
       <column name="size" type="varchar" length="5"></column>
-      <column name="sizeunitmeasurecode" type="bpchar"></column>
-      <column name="weightunitmeasurecode" type="bpchar"></column>
+      <column name="sizeunitmeasurecode" type="char" length="3"></column>
+      <column name="weightunitmeasurecode" type="char" length="3"></column>
       <column name="weight" type="numeric" precision="8" scale="2"></column>
       <column name="daystomanufacture" type="integer" nullable="false"></column>
-      <column name="productline" type="bpchar"></column>
-      <column name="class" type="bpchar"></column>
-      <column name="style" type="bpchar"></column>
+      <column name="productline" type="char" length="2"></column>
+      <column name="class" type="char" length="2"></column>
+      <column name="style" type="char" length="2"></column>
       <column name="productsubcategoryid" type="integer"></column>
       <column name="productmodelid" type="integer"></column>
       <column name="sellstartdate" type="timestamp" nullable="false"></column>
@@ -529,7 +529,7 @@
     <table name="productdocument">
       <column name="productid" type="integer" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
-      <column name="documentnode" type="varchar" nullable="false" default="&#39;/&#39;::varchar"></column>
+      <column name="documentnode" type="varchar" nullable="false" default="&#39;/&#39;"></column>
       <pk name="PK_ProductDocument_ProductID_DocumentNode">
         <column name="productid"></column>
         <column name="documentnode"></column>
@@ -606,7 +606,7 @@
     <table name="productmodelproductdescriptionculture">
       <column name="productmodelid" type="integer" nullable="false"></column>
       <column name="productdescriptionid" type="integer" nullable="false"></column>
-      <column name="cultureid" type="bpchar" nullable="false"></column>
+      <column name="cultureid" type="char" length="6" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
       <pk name="PK_ProductModelProductDescriptionCulture_ProductModelID_Product">
         <column name="productmodelid"></column>
@@ -691,7 +691,7 @@
       <column name="referenceorderid" type="integer" nullable="false"></column>
       <column name="referenceorderlineid" type="integer" nullable="false" default="0"></column>
       <column name="transactiondate" type="timestamp" nullable="false" default="now()"></column>
-      <column name="transactiontype" type="bpchar" nullable="false"></column>
+      <column name="transactiontype" type="char" length="1" nullable="false"></column>
       <column name="quantity" type="integer" nullable="false"></column>
       <column name="actualcost" type="numeric" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
@@ -709,7 +709,7 @@
       <column name="referenceorderid" type="integer" nullable="false"></column>
       <column name="referenceorderlineid" type="integer" nullable="false" default="0"></column>
       <column name="transactiondate" type="timestamp" nullable="false" default="now()"></column>
-      <column name="transactiontype" type="bpchar" nullable="false"></column>
+      <column name="transactiontype" type="char" length="1" nullable="false"></column>
       <column name="quantity" type="integer" nullable="false"></column>
       <column name="actualcost" type="numeric" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
@@ -719,7 +719,7 @@
       <check name="CK_TransactionHistoryArchive_TransactionType"><![CDATA[upper(transactiontype::text) = ANY(ARRAY['W'::text, 'S'::text, 'P'::text])]]></check>
     </table>
     <table name="unitmeasure">
-      <column name="unitmeasurecode" type="bpchar" nullable="false"></column>
+      <column name="unitmeasurecode" type="char" length="3" nullable="false"></column>
       <column name="name" type="Name" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
       <pk name="PK_UnitMeasure_UnitMeasureCode">
@@ -796,7 +796,7 @@
       <column name="minorderqty" type="integer" nullable="false"></column>
       <column name="maxorderqty" type="integer" nullable="false"></column>
       <column name="onorderqty" type="integer"></column>
-      <column name="unitmeasurecode" type="bpchar" nullable="false"></column>
+      <column name="unitmeasurecode" type="char" length="3" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
       <pk name="PK_ProductVendor_ProductID_BusinessEntityID">
         <column name="productid"></column>
@@ -909,7 +909,7 @@
   <schema name="sales">
     <table name="countryregioncurrency">
       <column name="countryregioncode" type="varchar" length="3" nullable="false"></column>
-      <column name="currencycode" type="bpchar" nullable="false"></column>
+      <column name="currencycode" type="char" length="3" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
       <pk name="PK_CountryRegionCurrency_CountryRegionCode_CurrencyCode">
         <column name="countryregioncode"></column>
@@ -934,7 +934,7 @@
       </pk>
     </table>
     <table name="currency">
-      <column name="currencycode" type="bpchar" nullable="false"></column>
+      <column name="currencycode" type="char" length="3" nullable="false"></column>
       <column name="name" type="Name" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>
       <pk name="PK_Currency_CurrencyCode">
@@ -944,8 +944,8 @@
     <table name="currencyrate">
       <column name="currencyrateid" type="integer" nullable="false"></column>
       <column name="currencyratedate" type="timestamp" nullable="false"></column>
-      <column name="fromcurrencycode" type="bpchar" nullable="false"></column>
-      <column name="tocurrencycode" type="bpchar" nullable="false"></column>
+      <column name="fromcurrencycode" type="char" length="3" nullable="false"></column>
+      <column name="tocurrencycode" type="char" length="3" nullable="false"></column>
       <column name="averagerate" type="numeric" nullable="false"></column>
       <column name="endofdayrate" type="numeric" nullable="false"></column>
       <column name="modifieddate" type="timestamp" nullable="false" default="now()"></column>

--- a/pkg/format/sql/testdata/adventureworks_generated.sql
+++ b/pkg/format/sql/testdata/adventureworks_generated.sql
@@ -120,8 +120,8 @@ CREATE TABLE "humanresources"."employee" (
 	"loginid" varchar(256) NOT NULL,
 	"jobtitle" varchar(50) NOT NULL,
 	"birthdate" date NOT NULL,
-	"maritalstatus" bpchar NOT NULL,
-	"gender" bpchar NOT NULL,
+	"maritalstatus" char(1) NOT NULL,
+	"gender" char(1) NOT NULL,
 	"hiredate" date NOT NULL,
 	"salariedflag" "Flag" NOT NULL DEFAULT true,
 	"vacationhours" smallint NOT NULL DEFAULT 0,
@@ -129,7 +129,7 @@ CREATE TABLE "humanresources"."employee" (
 	"currentflag" "Flag" NOT NULL DEFAULT true,
 	"rowguid" uuid NOT NULL DEFAULT public.uuid_generate_v1(),
 	"modifieddate" timestamp NOT NULL DEFAULT now(),
-	"organizationnode" varchar DEFAULT '/'::varchar,
+	"organizationnode" varchar DEFAULT '/',
 	CONSTRAINT "PK_Employee_BusinessEntityID" PRIMARY KEY("businessentityid"),
 	CONSTRAINT "CK_Employee_BirthDate" CHECK(birthdate >= '1930-01-01'::date AND birthdate <= (now() - '18 years'::interval)),
 	CONSTRAINT "CK_Employee_Gender" CHECK(upper(gender::text) = ANY(ARRAY['M'::text, 'F'::text])),
@@ -258,7 +258,7 @@ CREATE TABLE "person"."password" (
 
 CREATE TABLE "person"."person" (
 	"businessentityid" integer NOT NULL,
-	"persontype" bpchar NOT NULL,
+	"persontype" char(2) NOT NULL,
 	"namestyle" "NameStyle" NOT NULL DEFAULT false,
 	"title" varchar(8),
 	"firstname" "Name" NOT NULL,
@@ -292,7 +292,7 @@ CREATE TABLE "person"."phonenumbertype" (
 
 CREATE TABLE "person"."stateprovince" (
 	"stateprovinceid" integer NOT NULL,
-	"stateprovincecode" bpchar NOT NULL,
+	"stateprovincecode" char(3) NOT NULL,
 	"countryregioncode" varchar(3) NOT NULL,
 	"isonlystateprovinceflag" "Flag" NOT NULL DEFAULT true,
 	"name" "Name" NOT NULL,
@@ -308,7 +308,7 @@ CREATE TABLE "production"."billofmaterials" (
 	"componentid" integer NOT NULL,
 	"startdate" timestamp NOT NULL DEFAULT now(),
 	"enddate" timestamp,
-	"unitmeasurecode" bpchar NOT NULL,
+	"unitmeasurecode" char(3) NOT NULL,
 	"bomlevel" smallint NOT NULL,
 	"perassemblyqty" numeric(8,2) NOT NULL DEFAULT 1.00,
 	"modifieddate" timestamp NOT NULL DEFAULT now(),
@@ -320,7 +320,7 @@ CREATE TABLE "production"."billofmaterials" (
 );
 
 CREATE TABLE "production"."culture" (
-	"cultureid" bpchar NOT NULL,
+	"cultureid" char(6) NOT NULL,
 	"name" "Name" NOT NULL,
 	"modifieddate" timestamp NOT NULL DEFAULT now(),
 	CONSTRAINT "PK_Culture_CultureID" PRIMARY KEY("cultureid")
@@ -332,14 +332,14 @@ CREATE TABLE "production"."document" (
 	"folderflag" "Flag" NOT NULL DEFAULT false,
 	"filename" varchar(400) NOT NULL,
 	"fileextension" varchar(8),
-	"revision" bpchar NOT NULL,
+	"revision" char(5) NOT NULL,
 	"changenumber" integer NOT NULL DEFAULT 0,
 	"status" smallint NOT NULL,
 	"documentsummary" text,
 	"document" bytea,
 	"rowguid" uuid NOT NULL DEFAULT public.uuid_generate_v1(),
 	"modifieddate" timestamp NOT NULL DEFAULT now(),
-	"documentnode" varchar NOT NULL DEFAULT '/'::varchar,
+	"documentnode" varchar NOT NULL DEFAULT '/',
 	CONSTRAINT "PK_Document_DocumentNode" PRIMARY KEY("documentnode"),
 	CONSTRAINT "document_rowguid_key" UNIQUE("rowguid"),
 	CONSTRAINT "CK_Document_Status" CHECK(status >= 1 AND status <= 3)
@@ -375,13 +375,13 @@ CREATE TABLE "production"."product" (
 	"standardcost" numeric NOT NULL,
 	"listprice" numeric NOT NULL,
 	"size" varchar(5),
-	"sizeunitmeasurecode" bpchar,
-	"weightunitmeasurecode" bpchar,
+	"sizeunitmeasurecode" char(3),
+	"weightunitmeasurecode" char(3),
 	"weight" numeric(8,2),
 	"daystomanufacture" integer NOT NULL,
-	"productline" bpchar,
-	"class" bpchar,
-	"style" bpchar,
+	"productline" char(2),
+	"class" char(2),
+	"style" char(2),
 	"productsubcategoryid" integer,
 	"productmodelid" integer,
 	"sellstartdate" timestamp NOT NULL,
@@ -432,7 +432,7 @@ CREATE TABLE "production"."productdescription" (
 CREATE TABLE "production"."productdocument" (
 	"productid" integer NOT NULL,
 	"modifieddate" timestamp NOT NULL DEFAULT now(),
-	"documentnode" varchar NOT NULL DEFAULT '/'::varchar,
+	"documentnode" varchar NOT NULL DEFAULT '/',
 	CONSTRAINT "PK_ProductDocument_ProductID_DocumentNode" PRIMARY KEY("productid", "documentnode")
 );
 
@@ -479,7 +479,7 @@ CREATE TABLE "production"."productmodelillustration" (
 CREATE TABLE "production"."productmodelproductdescriptionculture" (
 	"productmodelid" integer NOT NULL,
 	"productdescriptionid" integer NOT NULL,
-	"cultureid" bpchar NOT NULL,
+	"cultureid" char(6) NOT NULL,
 	"modifieddate" timestamp NOT NULL DEFAULT now(),
 	CONSTRAINT "PK_ProductModelProductDescriptionCulture_ProductModelID_Product" PRIMARY KEY("productmodelid", "productdescriptionid", "cultureid")
 );
@@ -537,7 +537,7 @@ CREATE TABLE "production"."transactionhistory" (
 	"referenceorderid" integer NOT NULL,
 	"referenceorderlineid" integer NOT NULL DEFAULT 0,
 	"transactiondate" timestamp NOT NULL DEFAULT now(),
-	"transactiontype" bpchar NOT NULL,
+	"transactiontype" char(1) NOT NULL,
 	"quantity" integer NOT NULL,
 	"actualcost" numeric NOT NULL,
 	"modifieddate" timestamp NOT NULL DEFAULT now(),
@@ -551,7 +551,7 @@ CREATE TABLE "production"."transactionhistoryarchive" (
 	"referenceorderid" integer NOT NULL,
 	"referenceorderlineid" integer NOT NULL DEFAULT 0,
 	"transactiondate" timestamp NOT NULL DEFAULT now(),
-	"transactiontype" bpchar NOT NULL,
+	"transactiontype" char(1) NOT NULL,
 	"quantity" integer NOT NULL,
 	"actualcost" numeric NOT NULL,
 	"modifieddate" timestamp NOT NULL DEFAULT now(),
@@ -560,7 +560,7 @@ CREATE TABLE "production"."transactionhistoryarchive" (
 );
 
 CREATE TABLE "production"."unitmeasure" (
-	"unitmeasurecode" bpchar NOT NULL,
+	"unitmeasurecode" char(3) NOT NULL,
 	"name" "Name" NOT NULL,
 	"modifieddate" timestamp NOT NULL DEFAULT now(),
 	CONSTRAINT "PK_UnitMeasure_UnitMeasureCode" PRIMARY KEY("unitmeasurecode")
@@ -613,7 +613,7 @@ CREATE TABLE "purchasing"."productvendor" (
 	"minorderqty" integer NOT NULL,
 	"maxorderqty" integer NOT NULL,
 	"onorderqty" integer,
-	"unitmeasurecode" bpchar NOT NULL,
+	"unitmeasurecode" char(3) NOT NULL,
 	"modifieddate" timestamp NOT NULL DEFAULT now(),
 	CONSTRAINT "PK_ProductVendor_ProductID_BusinessEntityID" PRIMARY KEY("productid", "businessentityid"),
 	CONSTRAINT "CK_ProductVendor_AverageLeadTime" CHECK(averageleadtime >= 1),
@@ -689,7 +689,7 @@ CREATE TABLE "purchasing"."vendor" (
 
 CREATE TABLE "sales"."countryregioncurrency" (
 	"countryregioncode" varchar(3) NOT NULL,
-	"currencycode" bpchar NOT NULL,
+	"currencycode" char(3) NOT NULL,
 	"modifieddate" timestamp NOT NULL DEFAULT now(),
 	CONSTRAINT "PK_CountryRegionCurrency_CountryRegionCode_CurrencyCode" PRIMARY KEY("countryregioncode", "currencycode")
 );
@@ -705,7 +705,7 @@ CREATE TABLE "sales"."creditcard" (
 );
 
 CREATE TABLE "sales"."currency" (
-	"currencycode" bpchar NOT NULL,
+	"currencycode" char(3) NOT NULL,
 	"name" "Name" NOT NULL,
 	"modifieddate" timestamp NOT NULL DEFAULT now(),
 	CONSTRAINT "PK_Currency_CurrencyCode" PRIMARY KEY("currencycode")
@@ -714,8 +714,8 @@ CREATE TABLE "sales"."currency" (
 CREATE TABLE "sales"."currencyrate" (
 	"currencyrateid" integer NOT NULL,
 	"currencyratedate" timestamp NOT NULL,
-	"fromcurrencycode" bpchar NOT NULL,
-	"tocurrencycode" bpchar NOT NULL,
+	"fromcurrencycode" char(3) NOT NULL,
+	"tocurrencycode" char(3) NOT NULL,
 	"averagerate" numeric NOT NULL,
 	"endofdayrate" numeric NOT NULL,
 	"modifieddate" timestamp NOT NULL DEFAULT now(),

--- a/pkg/format/sql/testdata/airlines.pgd
+++ b/pkg/format/sql/testdata/airlines.pgd
@@ -14,7 +14,7 @@
   </sequences>
   <schema name="bookings">
     <table name="aircrafts_data">
-      <column name="aircraft_code" type="bpchar" nullable="false"></column>
+      <column name="aircraft_code" type="char" length="3" nullable="false"></column>
       <column name="model" type="jsonb" nullable="false"></column>
       <column name="range" type="integer" nullable="false"></column>
       <pk name="aircrafts_pkey">
@@ -23,7 +23,7 @@
       <check name="aircrafts_range_check"><![CDATA[range > 0]]></check>
     </table>
     <table name="airports_data">
-      <column name="airport_code" type="bpchar" nullable="false"></column>
+      <column name="airport_code" type="char" length="3" nullable="false"></column>
       <column name="airport_name" type="jsonb" nullable="false"></column>
       <column name="city" type="jsonb" nullable="false"></column>
       <column name="coordinates" type="point" nullable="false"></column>
@@ -33,7 +33,7 @@
       </pk>
     </table>
     <table name="boarding_passes">
-      <column name="ticket_no" type="bpchar" nullable="false"></column>
+      <column name="ticket_no" type="char" length="13" nullable="false"></column>
       <column name="flight_id" type="integer" nullable="false"></column>
       <column name="boarding_no" type="integer" nullable="false"></column>
       <column name="seat_no" type="varchar" length="4" nullable="false"></column>
@@ -55,7 +55,7 @@
       </unique>
     </table>
     <table name="bookings">
-      <column name="book_ref" type="bpchar" nullable="false"></column>
+      <column name="book_ref" type="char" length="6" nullable="false"></column>
       <column name="book_date" type="timestamptz" nullable="false"></column>
       <column name="total_amount" type="numeric" precision="10" scale="2" nullable="false"></column>
       <pk name="bookings_pkey">
@@ -64,13 +64,13 @@
     </table>
     <table name="flights">
       <column name="flight_id" type="integer" nullable="false"></column>
-      <column name="flight_no" type="bpchar" nullable="false"></column>
+      <column name="flight_no" type="char" length="6" nullable="false"></column>
       <column name="scheduled_departure" type="timestamptz" nullable="false"></column>
       <column name="scheduled_arrival" type="timestamptz" nullable="false"></column>
-      <column name="departure_airport" type="bpchar" nullable="false"></column>
-      <column name="arrival_airport" type="bpchar" nullable="false"></column>
+      <column name="departure_airport" type="char" length="3" nullable="false"></column>
+      <column name="arrival_airport" type="char" length="3" nullable="false"></column>
       <column name="status" type="varchar" length="20" nullable="false"></column>
-      <column name="aircraft_code" type="bpchar" nullable="false"></column>
+      <column name="aircraft_code" type="char" length="3" nullable="false"></column>
       <column name="actual_departure" type="timestamptz"></column>
       <column name="actual_arrival" type="timestamptz"></column>
       <pk name="flights_pkey">
@@ -94,7 +94,7 @@
       <check name="flights_status_check"><![CDATA[status::text = ANY(ARRAY['On Time'::varchar::text, 'Delayed'::varchar::text, 'Departed'::varchar::text, 'Arrived'::varchar::text, 'Scheduled'::varchar::text, 'Cancelled'::varchar::text])]]></check>
     </table>
     <table name="seats">
-      <column name="aircraft_code" type="bpchar" nullable="false"></column>
+      <column name="aircraft_code" type="char" length="3" nullable="false"></column>
       <column name="seat_no" type="varchar" length="4" nullable="false"></column>
       <column name="fare_conditions" type="varchar" length="10" nullable="false"></column>
       <pk name="seats_pkey">
@@ -107,7 +107,7 @@
       <check name="seats_fare_conditions_check"><![CDATA[fare_conditions::text = ANY(ARRAY['Economy'::varchar::text, 'Comfort'::varchar::text, 'Business'::varchar::text])]]></check>
     </table>
     <table name="ticket_flights">
-      <column name="ticket_no" type="bpchar" nullable="false"></column>
+      <column name="ticket_no" type="char" length="13" nullable="false"></column>
       <column name="flight_id" type="integer" nullable="false"></column>
       <column name="fare_conditions" type="varchar" length="10" nullable="false"></column>
       <column name="amount" type="numeric" precision="10" scale="2" nullable="false"></column>
@@ -125,8 +125,8 @@
       <check name="ticket_flights_fare_conditions_check"><![CDATA[fare_conditions::text = ANY(ARRAY['Economy'::varchar::text, 'Comfort'::varchar::text, 'Business'::varchar::text])]]></check>
     </table>
     <table name="tickets">
-      <column name="ticket_no" type="bpchar" nullable="false"></column>
-      <column name="book_ref" type="bpchar" nullable="false"></column>
+      <column name="ticket_no" type="char" length="13" nullable="false"></column>
+      <column name="book_ref" type="char" length="6" nullable="false"></column>
       <column name="passenger_id" type="varchar" length="20" nullable="false"></column>
       <column name="passenger_name" type="text" nullable="false"></column>
       <column name="contact_data" type="jsonb"></column>

--- a/pkg/format/sql/testdata/airlines_generated.sql
+++ b/pkg/format/sql/testdata/airlines_generated.sql
@@ -3,7 +3,7 @@ CREATE SCHEMA IF NOT EXISTS "bookings";
 CREATE SEQUENCE "bookings"."flights_flight_id_seq" INCREMENT BY 1 START WITH 1 CACHE 1;
 
 CREATE TABLE "bookings"."aircrafts_data" (
-	"aircraft_code" bpchar NOT NULL,
+	"aircraft_code" char(3) NOT NULL,
 	"model" jsonb NOT NULL,
 	"range" integer NOT NULL,
 	CONSTRAINT "aircrafts_pkey" PRIMARY KEY("aircraft_code"),
@@ -11,7 +11,7 @@ CREATE TABLE "bookings"."aircrafts_data" (
 );
 
 CREATE TABLE "bookings"."airports_data" (
-	"airport_code" bpchar NOT NULL,
+	"airport_code" char(3) NOT NULL,
 	"airport_name" jsonb NOT NULL,
 	"city" jsonb NOT NULL,
 	"coordinates" point NOT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE "bookings"."airports_data" (
 );
 
 CREATE TABLE "bookings"."boarding_passes" (
-	"ticket_no" bpchar NOT NULL,
+	"ticket_no" char(13) NOT NULL,
 	"flight_id" integer NOT NULL,
 	"boarding_no" integer NOT NULL,
 	"seat_no" varchar(4) NOT NULL,
@@ -30,7 +30,7 @@ CREATE TABLE "bookings"."boarding_passes" (
 );
 
 CREATE TABLE "bookings"."bookings" (
-	"book_ref" bpchar NOT NULL,
+	"book_ref" char(6) NOT NULL,
 	"book_date" timestamptz NOT NULL,
 	"total_amount" numeric(10,2) NOT NULL,
 	CONSTRAINT "bookings_pkey" PRIMARY KEY("book_ref")
@@ -38,13 +38,13 @@ CREATE TABLE "bookings"."bookings" (
 
 CREATE TABLE "bookings"."flights" (
 	"flight_id" integer NOT NULL,
-	"flight_no" bpchar NOT NULL,
+	"flight_no" char(6) NOT NULL,
 	"scheduled_departure" timestamptz NOT NULL,
 	"scheduled_arrival" timestamptz NOT NULL,
-	"departure_airport" bpchar NOT NULL,
-	"arrival_airport" bpchar NOT NULL,
+	"departure_airport" char(3) NOT NULL,
+	"arrival_airport" char(3) NOT NULL,
 	"status" varchar(20) NOT NULL,
-	"aircraft_code" bpchar NOT NULL,
+	"aircraft_code" char(3) NOT NULL,
 	"actual_departure" timestamptz,
 	"actual_arrival" timestamptz,
 	CONSTRAINT "flights_pkey" PRIMARY KEY("flight_id"),
@@ -55,7 +55,7 @@ CREATE TABLE "bookings"."flights" (
 );
 
 CREATE TABLE "bookings"."seats" (
-	"aircraft_code" bpchar NOT NULL,
+	"aircraft_code" char(3) NOT NULL,
 	"seat_no" varchar(4) NOT NULL,
 	"fare_conditions" varchar(10) NOT NULL,
 	CONSTRAINT "seats_pkey" PRIMARY KEY("aircraft_code", "seat_no"),
@@ -63,7 +63,7 @@ CREATE TABLE "bookings"."seats" (
 );
 
 CREATE TABLE "bookings"."ticket_flights" (
-	"ticket_no" bpchar NOT NULL,
+	"ticket_no" char(13) NOT NULL,
 	"flight_id" integer NOT NULL,
 	"fare_conditions" varchar(10) NOT NULL,
 	"amount" numeric(10,2) NOT NULL,
@@ -73,8 +73,8 @@ CREATE TABLE "bookings"."ticket_flights" (
 );
 
 CREATE TABLE "bookings"."tickets" (
-	"ticket_no" bpchar NOT NULL,
-	"book_ref" bpchar NOT NULL,
+	"ticket_no" char(13) NOT NULL,
+	"book_ref" char(6) NOT NULL,
 	"passenger_id" varchar(20) NOT NULL,
 	"passenger_name" text NOT NULL,
 	"contact_data" jsonb,

--- a/pkg/format/sql/testdata/pagila.pgd
+++ b/pkg/format/sql/testdata/pagila.pgd
@@ -184,7 +184,7 @@
     </table>
     <table name="language">
       <column name="language_id" type="integer" nullable="false" default="nextval(&#39;public.language_language_id_seq&#39;::regclass)"></column>
-      <column name="name" type="bpchar" nullable="false"></column>
+      <column name="name" type="char" length="20" nullable="false"></column>
       <column name="last_update" type="timestamptz" nullable="false" default="now()"></column>
       <pk name="language_pkey">
         <column name="language_id"></column>

--- a/pkg/format/sql/testdata/pagila_generated.sql
+++ b/pkg/format/sql/testdata/pagila_generated.sql
@@ -128,7 +128,7 @@ CREATE TABLE "inventory" (
 
 CREATE TABLE "language" (
 	"language_id" integer NOT NULL DEFAULT nextval('public.language_language_id_seq'::regclass),
-	"name" bpchar NOT NULL,
+	"name" char(20) NOT NULL,
 	"last_update" timestamptz NOT NULL DEFAULT now(),
 	CONSTRAINT "language_pkey" PRIMARY KEY("language_id")
 );

--- a/pkg/pgd/ddl.go
+++ b/pkg/pgd/ddl.go
@@ -839,10 +839,14 @@ func pkDef(pk *PrimaryKey) string {
 }
 
 func uniqueDef(u *Unique) string {
-	if u.Name != "" {
-		return fmt.Sprintf("CONSTRAINT %s UNIQUE(%s)", QuoteIdent(u.Name), QuotedColList(u.Columns))
+	nullsDistinct := ""
+	if u.NullsDistinct == "false" {
+		nullsDistinct = " NULLS NOT DISTINCT"
 	}
-	return fmt.Sprintf("UNIQUE(%s)", QuotedColList(u.Columns))
+	if u.Name != "" {
+		return fmt.Sprintf("CONSTRAINT %s UNIQUE%s(%s)", QuoteIdent(u.Name), nullsDistinct, QuotedColList(u.Columns))
+	}
+	return fmt.Sprintf("UNIQUE%s(%s)", nullsDistinct, QuotedColList(u.Columns))
 }
 
 func checkDef(c *Check) string {
@@ -855,16 +859,24 @@ func checkDef(c *Check) string {
 func excludeDef(e *Exclude) string {
 	var elems []string
 	for _, el := range e.Elements {
-		elems = append(elems, fmt.Sprintf("%s WITH %s", QuoteIdent(el.Column), el.With))
+		target := QuoteIdent(el.Column)
+		if el.Expression != "" {
+			target = el.Expression
+		}
+		elems = append(elems, fmt.Sprintf("%s WITH %s", target, el.With))
 	}
 	using := ""
 	if e.Using != "" {
 		using = fmt.Sprintf(" USING %s", e.Using)
 	}
-	if e.Name != "" {
-		return fmt.Sprintf("CONSTRAINT %s EXCLUDE%s (%s)", QuoteIdent(e.Name), using, strings.Join(elems, ", "))
+	where := ""
+	if e.Where != nil && strings.TrimSpace(e.Where.Value) != "" {
+		where = fmt.Sprintf(" WHERE (%s)", strings.TrimSpace(e.Where.Value))
 	}
-	return fmt.Sprintf("EXCLUDE%s (%s)", using, strings.Join(elems, ", "))
+	if e.Name != "" {
+		return fmt.Sprintf("CONSTRAINT %s EXCLUDE%s (%s)%s", QuoteIdent(e.Name), using, strings.Join(elems, ", "), where)
+	}
+	return fmt.Sprintf("EXCLUDE%s (%s)%s", using, strings.Join(elems, ", "), where)
 }
 
 // sortFunctionsByDeps orders functions so that if A's body references B's name, B comes first.
@@ -1091,6 +1103,13 @@ func (d *ddlWriter) writeIndex(q string, idx *Index) {
 	d.P("%s ON %s%s", QuoteIdent(idx.Name), q, QuoteIdent(idx.Table))
 	d.If(idx.Using != "" && idx.Using != "btree", " USING %s", strings.ToUpper(idx.Using))
 	d.P(" (\n%s\n)", indexElements(idx))
+	if idx.With != nil && len(idx.With.Params) > 0 {
+		var params []string
+		for _, p := range idx.With.Params {
+			params = append(params, fmt.Sprintf("%s='%s'", p.Name, p.Value))
+		}
+		d.P("\n\tWITH (%s)", strings.Join(params, ", "))
+	}
 	if idx.Where != nil && idx.Where.Value != "" {
 		d.P("\n\tWHERE %s", idx.Where.Value)
 	}

--- a/pkg/pgd/model.go
+++ b/pkg/pgd/model.go
@@ -324,12 +324,14 @@ type Exclude struct {
 	Name     string           `xml:"name,attr"`
 	Using    string           `xml:"using,attr,omitempty"`
 	Elements []ExcludeElement `xml:"element"`
+	Where    *WhereClause     `xml:"where,omitempty"`
 }
 
 // ExcludeElement is one element of an EXCLUDE constraint.
 type ExcludeElement struct {
-	Column string `xml:"column,attr"`
-	With   string `xml:"with,attr"`
+	Column     string `xml:"column,attr,omitempty"`
+	Expression string `xml:"expression,attr,omitempty"`
+	With       string `xml:"with,attr"`
 }
 
 // With holds storage parameters (fillfactor, autovacuum_enabled, etc.).
@@ -384,6 +386,7 @@ type Index struct {
 	Columns       []ColRef     `xml:"column,omitempty"`
 	Expressions   []Expression `xml:"expression,omitempty"`
 	Include       *Include     `xml:"include,omitempty"`
+	With          *With        `xml:"with,omitempty"`
 	Where         *WhereClause `xml:"where,omitempty"`
 }
 

--- a/pkg/pgd/types.go
+++ b/pkg/pgd/types.go
@@ -19,7 +19,7 @@ func NormalizeType(t string) string {
 		return "boolean"
 	case "character varying":
 		return "varchar"
-	case "character":
+	case "character", "bpchar":
 		return "char"
 	case "bit varying":
 		return "varbit"


### PR DESCRIPTION
## Summary

Full round-trip verification for sellersrv and apisrv databases revealed and fixed multiple import/export bugs across SQL parser, PDD converter, DDL generator, and PG introspector.

### SQL parser + DDL generator
- EXCLUDE constraints with expression elements and WHERE clause
- NULLS NOT DISTINCT for UNIQUE constraints  
- Index WITH storage params (fastupdate, etc.)
- Fix COMMENT ON TYPE losing type name (Node_TypeName)
- Fix varchar(N)[] losing length
- Strip redundant type casts from defaults and WHERE clauses
- Normalize bpchar → char

### PDD converter
- Parse ENUM types with labels and comments
- Decode \NNNN hex unicode codepoints (Cyrillic)
- Normalize boolean defaults, strip type casts, skip DEFAULT NULL
- Skip identity on non-integer types (uuid)
- Skip PK/UNIQUE backing indexes (ReferenceConstraint)
- Detect uuid-ossp extension, PG-convention PK naming fallback
- Fix varchar(N)[] losing length

### PG introspector
- Fix enum labels deserialization (pg:",array" tag)
- Fix error propagation in introspectFull
- Filter extension-owned functions from introspect
- Parse EXCLUDE constraint elements via pg_query
- Parse index WITH storage params, fix expression index column splitting
- Preserve DESC/NULLS FIRST/LAST in index columns
- Parse NULLS NOT DISTINCT from constraintdef
- Fix varchar(N)[] losing length

## Test plan
- [x] `make fmt && make lint && make test` — all pass, 0 lint issues
- [x] sellersrv SQL round-trip: **OK** (0 diff)
- [x] sellersrv introspect round-trip: **0 psql errors, 0 diff**
- [x] apisrv PDD→DDL: **0 psql errors**
- [x] apisrv introspect round-trip: **0 psql errors, 0 diff**