### PR TITLE
Add exclude/index-with params, fix SQL PK naming, add camelCase lint

### DIFF
--- a/frontend/src/api/factory.generated.ts
+++ b/frontend/src/api/factory.generated.ts
@@ -228,23 +228,27 @@ export interface IERDTable {
 export interface IExcludeDetail {
   name: string,
   using: string,
-  elements: Array<IExcludeElementDetail>
+  elements: Array<IExcludeElementDetail>,
+  where: string
 }
 
 export interface IExcludeElementDetail {
   column: string,
+  expression: string,
   with: string
 }
 
 export interface IExcludeElementInput {
   column: string,
+  expression: string,
   with: string
 }
 
 export interface IExcludeInput {
   name: string,
   using: string,
-  elements: Array<IExcludeElementInput>
+  elements: Array<IExcludeElementInput>,
+  where: string
 }
 
 export interface IFKColDetail {
@@ -325,6 +329,7 @@ export interface IIndexDetail {
   using: string,
   columns: Array<IIndexColDetail>,
   expressions: Array<string>,
+  with: Array<IWithParamDetail>,
   where: string,
   include: Array<string>
 }
@@ -337,6 +342,7 @@ export interface IIndexInput {
   using: string,
   columns: Array<IIndexColInput>,
   expressions: Array<string>,
+  with: Array<IWithParamInput>,
   where: string,
   include: Array<string>
 }
@@ -572,6 +578,16 @@ export interface IUpdateInfo {
   updateAvailable: boolean,
   releaseURL: string,
   shouldNotify: boolean
+}
+
+export interface IWithParamDetail {
+  name: string,
+  value: string
+}
+
+export interface IWithParamInput {
+  name: string,
+  value: string
 }
 
 export const factory = (send: any) => ({

--- a/frontend/src/api/factory.generated.ts
+++ b/frontend/src/api/factory.generated.ts
@@ -235,12 +235,14 @@ export interface IExcludeDetail {
 export interface IExcludeElementDetail {
   column: string,
   expression: string,
+  opclass: string,
   with: string
 }
 
 export interface IExcludeElementInput {
   column: string,
   expression: string,
+  opclass: string,
   with: string
 }
 

--- a/frontend/src/components/editor/TableEditorDialog.vue
+++ b/frontend/src/components/editor/TableEditorDialog.vue
@@ -231,7 +231,7 @@ function onCreateIndex(columnName: string) {
   }
   const newIndex = {
     name, unique: false, nullsDistinct: false, using: 'btree',
-    columns: [{ name: columnName, order: '', nulls: '', opclass: '' }], expressions: [], where: '', include: [],
+    columns: [{ name: columnName, order: '', nulls: '', opclass: '' }], expressions: [], with: [], where: '', include: [],
   }
   editor.draft.indexes = [...(editor.draft.indexes || []), newIndex]
   activeTab.value = 'indexes'

--- a/frontend/src/components/editor/tabs/ConstraintList.vue
+++ b/frontend/src/components/editor/tabs/ConstraintList.vue
@@ -83,7 +83,7 @@ function addExclude() {
   const c = props.checks || []
   const e = props.excludes || []
   const name = `excl_${props.tableName}_${e.length + 1}`
-  emit('updateExcludes', [...e, { name, using: 'gist', elements: [{ column: '', expression: '', with: '=' }], where: '' }])
+  emit('updateExcludes', [...e, { name, using: 'gist', elements: [{ column: '', expression: '', opclass: '', with: '=' }], where: '' }])
   const newIdx = (props.pk ? 1 : 0) + u.length + c.length + e.length
   selectedIdx.value = newIdx
 }

--- a/frontend/src/components/editor/tabs/ConstraintList.vue
+++ b/frontend/src/components/editor/tabs/ConstraintList.vue
@@ -78,6 +78,16 @@ function addCheck() {
   selectedIdx.value = newIdx
 }
 
+function addExclude() {
+  const u = props.uniques || []
+  const c = props.checks || []
+  const e = props.excludes || []
+  const name = `excl_${props.tableName}_${e.length + 1}`
+  emit('updateExcludes', [...e, { name, using: 'gist', elements: [{ column: '', expression: '', with: '=' }], where: '' }])
+  const newIdx = (props.pk ? 1 : 0) + u.length + c.length + e.length
+  selectedIdx.value = newIdx
+}
+
 function deleteSelected() {
   if (selected.value == null) return
   const item = selected.value
@@ -104,6 +114,11 @@ function onUpdateCheck(index: number, data: ICheckDetail) {
   const copy = [...props.checks]
   copy[index] = data
   emit('updateChecks', copy)
+}
+function onUpdateExclude(index: number, data: IExcludeDetail) {
+  const copy = [...props.excludes]
+  copy[index] = data
+  emit('updateExcludes', copy)
 }
 
 const { editingIdx, editName, editError, startEdit: startEditName, commit: commitEditName, onEditKeydown } = useInlineEdit({
@@ -177,6 +192,7 @@ function onKeydown(e: KeyboardEvent) {
       <div class="cl-toolbar">
         <button class="cl-btn" title="Add UNIQUE (+)" @click="addUnique">+ Unique</button>
         <button class="cl-btn" title="Add CHECK" @click="addCheck">+ Check</button>
+        <button class="cl-btn" title="Add EXCLUDE" @click="addExclude">+ Exclude</button>
         <button class="cl-btn" title="Delete (−)" :disabled="selected == null || selected.kind === 'pk'" @click="deleteSelected">− Delete</button>
       </div>
     </div>
@@ -188,6 +204,7 @@ function onKeydown(e: KeyboardEvent) {
         @update-p-k="onUpdatePK"
         @update-unique="onUpdateUnique"
         @update-check="onUpdateCheck"
+        @update-exclude="onUpdateExclude"
       />
     </div>
   </div>

--- a/frontend/src/components/editor/tabs/ConstraintList.vue
+++ b/frontend/src/components/editor/tabs/ConstraintList.vue
@@ -57,7 +57,7 @@ function itemDetail(item: ConstraintItem): string {
     case 'pk': return item.data.columns.join(', ')
     case 'unique': return item.data.columns.join(', ')
     case 'check': return item.data.expression
-    case 'exclude': return item.data.elements.map(el => `${el.column} WITH ${el.with}`).join(', ')
+    case 'exclude': return item.data.elements.map(el => `${el.expression || el.column} WITH ${el.with}`).join(', ')
   }
 }
 

--- a/frontend/src/components/editor/tabs/ConstraintProperties.vue
+++ b/frontend/src/components/editor/tabs/ConstraintProperties.vue
@@ -119,8 +119,14 @@ function setCheck(field: string, value: string) {
       </div>
       <div class="cp-group-label">Elements</div>
       <div v-for="(el, i) in item.data.elements" :key="i" class="cp-row">
-        <span class="cp-mono">{{ el.column }} WITH {{ el.with }}</span>
+        <span class="cp-mono">{{ el.expression || el.column }} WITH {{ el.with }}</span>
       </div>
+      <template v-if="item.data.where">
+        <div class="cp-group-label">Where</div>
+        <div class="cp-row">
+          <span class="cp-mono cp-where">{{ item.data.where }}</span>
+        </div>
+      </template>
     </template>
   </div>
 </template>
@@ -147,4 +153,5 @@ function setCheck(field: string, value: string) {
 .cp-check-row { margin-bottom: 0.154rem; }
 .cp-check { font-size: 0.923rem; display: flex; align-items: center; gap: 0.308rem; cursor: pointer; }
 .cp-mono { font-family: monospace; font-size: 0.846rem; color: var(--color-text-secondary); }
+.cp-where { word-break: break-all; }
 </style>

--- a/frontend/src/components/editor/tabs/ConstraintProperties.vue
+++ b/frontend/src/components/editor/tabs/ConstraintProperties.vue
@@ -16,6 +16,7 @@ const emit = defineEmits<{
   updatePK: [pk: IPKDetail]
   updateUnique: [index: number, data: IUniqueDetail]
   updateCheck: [index: number, data: ICheckDetail]
+  updateExclude: [index: number, data: IExcludeDetail]
 }>()
 
 function togglePKColumn(colName: string) {
@@ -49,6 +50,42 @@ function toggleUniqueColumn(colName: string) {
 function setCheck(field: string, value: string) {
   if (props.item.kind !== 'check') return
   emit('updateCheck', props.item.index, { ...props.item.data, [field]: value })
+}
+
+function setExclude(field: string, value: string) {
+  if (props.item.kind !== 'exclude') return
+  emit('updateExclude', props.item.index, { ...props.item.data, [field]: value })
+}
+
+function updateExclElement(i: number, field: string, value: string) {
+  if (props.item.kind !== 'exclude') return
+  const elements = [...props.item.data.elements]
+  elements[i] = { ...elements[i]!, [field]: value }
+  emit('updateExclude', props.item.index, { ...props.item.data, elements })
+}
+
+function addExclElement() {
+  if (props.item.kind !== 'exclude') return
+  const elements = [...props.item.data.elements, { column: '', expression: '', with: '=' }]
+  emit('updateExclude', props.item.index, { ...props.item.data, elements })
+}
+
+function removeExclElement(i: number) {
+  if (props.item.kind !== 'exclude') return
+  const elements = props.item.data.elements.filter((_, j) => j !== i)
+  emit('updateExclude', props.item.index, { ...props.item.data, elements })
+}
+
+function toggleExclElementMode(i: number) {
+  if (props.item.kind !== 'exclude') return
+  const elements = [...props.item.data.elements]
+  const el = elements[i]!
+  if (el.expression) {
+    elements[i] = { column: el.column, expression: '', with: el.with }
+  } else {
+    elements[i] = { column: '', expression: el.column || ' ', with: el.with }
+  }
+  emit('updateExclude', props.item.index, { ...props.item.data, elements })
 }
 </script>
 
@@ -106,27 +143,56 @@ function setCheck(field: string, value: string) {
       </div>
     </template>
 
-    <!-- Exclude (read-only) -->
+    <!-- Exclude -->
     <template v-else-if="item.kind === 'exclude'">
-      <div class="cp-title">Exclude Constraint (read-only)</div>
+      <div class="cp-title">Exclude Constraint</div>
       <div class="cp-row">
         <label class="cp-label">Name</label>
-        <input class="cp-input" :value="item.data.name" disabled />
+        <input class="cp-input" :value="item.data.name" @change="setExclude('name', ($event.target as HTMLInputElement).value)" />
       </div>
       <div class="cp-row">
         <label class="cp-label">Using</label>
-        <input class="cp-input" :value="item.data.using" disabled />
+        <select class="cp-input" :value="item.data.using || 'gist'" @change="setExclude('using', ($event.target as HTMLSelectElement).value)">
+          <option value="gist">gist</option>
+          <option value="btree">btree</option>
+          <option value="hash">hash</option>
+          <option value="gin">gin</option>
+          <option value="spgist">spgist</option>
+          <option value="brin">brin</option>
+        </select>
       </div>
+
       <div class="cp-group-label">Elements</div>
-      <div v-for="(el, i) in item.data.elements" :key="i" class="cp-row">
-        <span class="cp-mono">{{ el.expression || el.column }} WITH {{ el.with }}</span>
-      </div>
-      <template v-if="item.data.where">
-        <div class="cp-group-label">Where</div>
-        <div class="cp-row">
-          <span class="cp-mono cp-where">{{ item.data.where }}</span>
+      <div v-for="(el, i) in item.data.elements" :key="i" class="cp-elem">
+        <div class="cp-elem-header">
+          <label class="cp-check">
+            <input type="radio" :name="`excl-mode-${i}`" :checked="!el.expression" @change="toggleExclElementMode(i)" /> Column
+          </label>
+          <label class="cp-check">
+            <input type="radio" :name="`excl-mode-${i}`" :checked="!!el.expression" @change="toggleExclElementMode(i)" /> Expression
+          </label>
+          <button class="cp-btn-del" @click="removeExclElement(i)">×</button>
         </div>
-      </template>
+        <div v-if="!el.expression" class="cp-row">
+          <select class="cp-input" :value="el.column" @change="updateExclElement(i, 'column', ($event.target as HTMLSelectElement).value)">
+            <option value="">(select)</option>
+            <option v-for="c in columns" :key="c" :value="c">{{ c }}</option>
+          </select>
+        </div>
+        <div v-else class="cp-row">
+          <input class="cp-input cp-mono" :value="el.expression" placeholder="SQL expression" @change="updateExclElement(i, 'expression', ($event.target as HTMLInputElement).value)" />
+        </div>
+        <div class="cp-row">
+          <label class="cp-label-sm">WITH</label>
+          <input class="cp-input cp-with" :value="el.with" placeholder="=" @change="updateExclElement(i, 'with', ($event.target as HTMLInputElement).value)" />
+        </div>
+      </div>
+      <button class="cp-btn-add" @click="addExclElement">+ Add element</button>
+
+      <div class="cp-group-label">Where</div>
+      <div class="cp-row">
+        <textarea class="cp-textarea cp-mono" :value="item.data.where || ''" rows="2" placeholder="partial constraint predicate" @change="setExclude('where', ($event.target as HTMLTextAreaElement).value)" />
+      </div>
     </template>
   </div>
 </template>
@@ -152,6 +218,18 @@ function setCheck(field: string, value: string) {
 .cp-group-label { font-size: 0.769rem; font-weight: 600; color: var(--color-text-muted); margin: 0.462rem 0 0.231rem; }
 .cp-check-row { margin-bottom: 0.154rem; }
 .cp-check { font-size: 0.923rem; display: flex; align-items: center; gap: 0.308rem; cursor: pointer; }
-.cp-mono { font-family: monospace; font-size: 0.846rem; color: var(--color-text-secondary); }
-.cp-where { word-break: break-all; }
+.cp-mono { font-family: monospace; font-size: 0.846rem; }
+.cp-elem { margin-bottom: 0.462rem; padding: 0.308rem; border: 1px solid var(--color-border-subtle); border-radius: 2px; }
+.cp-elem-header { display: flex; align-items: center; gap: 0.462rem; margin-bottom: 0.308rem; }
+.cp-label-sm { width: 2.5rem; font-size: 0.846rem; color: var(--color-text-secondary); flex-shrink: 0; }
+.cp-with { max-width: 4rem; }
+.cp-btn-del {
+  width: 1.385rem; height: 1.385rem; font-size: 0.846rem; margin-left: auto;
+  border: 1px solid var(--color-border); background: var(--color-bg-surface);
+  color: var(--color-text-secondary); cursor: pointer; display: flex; align-items: center; justify-content: center;
+}
+.cp-btn-del:hover { background: var(--color-bg-hover); color: #cc3333; }
+.cp-btn-add { font-size: 0.769rem; color: var(--color-accent); background: none; border: none; cursor: pointer; padding: 0; margin-bottom: 0.462rem; }
+.cp-btn-add:hover { text-decoration: underline; }
+select.cp-input { cursor: pointer; }
 </style>

--- a/frontend/src/components/editor/tabs/ConstraintProperties.vue
+++ b/frontend/src/components/editor/tabs/ConstraintProperties.vue
@@ -66,7 +66,7 @@ function updateExclElement(i: number, field: string, value: string) {
 
 function addExclElement() {
   if (props.item.kind !== 'exclude') return
-  const elements = [...props.item.data.elements, { column: '', expression: '', with: '=' }]
+  const elements = [...props.item.data.elements, { column: '', expression: '', opclass: '', with: '=' }]
   emit('updateExclude', props.item.index, { ...props.item.data, elements })
 }
 
@@ -81,9 +81,9 @@ function toggleExclElementMode(i: number) {
   const elements = [...props.item.data.elements]
   const el = elements[i]!
   if (el.expression) {
-    elements[i] = { column: el.column, expression: '', with: el.with }
+    elements[i] = { column: el.column, expression: '', opclass: el.opclass, with: el.with }
   } else {
-    elements[i] = { column: '', expression: el.column || ' ', with: el.with }
+    elements[i] = { column: '', expression: el.column || ' ', opclass: el.opclass, with: el.with }
   }
   emit('updateExclude', props.item.index, { ...props.item.data, elements })
 }
@@ -154,11 +154,9 @@ function toggleExclElementMode(i: number) {
         <label class="cp-label">Using</label>
         <select class="cp-input" :value="item.data.using || 'gist'" @change="setExclude('using', ($event.target as HTMLSelectElement).value)">
           <option value="gist">gist</option>
+          <option value="spgist">spgist</option>
           <option value="btree">btree</option>
           <option value="hash">hash</option>
-          <option value="gin">gin</option>
-          <option value="spgist">spgist</option>
-          <option value="brin">brin</option>
         </select>
       </div>
 
@@ -181,6 +179,10 @@ function toggleExclElementMode(i: number) {
         </div>
         <div v-else class="cp-row">
           <input class="cp-input cp-mono" :value="el.expression" placeholder="SQL expression" @change="updateExclElement(i, 'expression', ($event.target as HTMLInputElement).value)" />
+        </div>
+        <div class="cp-row">
+          <label class="cp-label-sm">Opclass</label>
+          <input class="cp-input" :value="el.opclass" placeholder="opclass" @change="updateExclElement(i, 'opclass', ($event.target as HTMLInputElement).value)" />
         </div>
         <div class="cp-row">
           <label class="cp-label-sm">WITH</label>

--- a/frontend/src/components/editor/tabs/IndexList.vue
+++ b/frontend/src/components/editor/tabs/IndexList.vue
@@ -21,7 +21,7 @@ const emit = defineEmits<{
 function addIndex() {
   const idxs = props.indexes || []
   const name = `ix_${props.tableName}_${idxs.length + 1}`
-  emit('updateIndexes', [...idxs, { name, unique: false, nullsDistinct: false, using: 'btree', columns: [], expressions: [], where: '', include: [] }])
+  emit('updateIndexes', [...idxs, { name, unique: false, nullsDistinct: false, using: 'btree', columns: [], expressions: [], with: [], where: '', include: [] }])
   selectedIdx.value = idxs.length
 }
 

--- a/frontend/src/components/editor/tabs/IndexProperties.vue
+++ b/frontend/src/components/editor/tabs/IndexProperties.vue
@@ -86,7 +86,7 @@ function updateCol(i: number, field: string, value: string) {
 
     <template v-if="index.with?.length">
       <div class="ip-section-label">Storage Params</div>
-      <div v-for="(p, i) in index.with" :key="i" class="ip-row">
+      <div v-for="p in index.with" :key="p.name" class="ip-row">
         <span class="ip-mono">{{ p.name }} = {{ p.value }}</span>
       </div>
     </template>

--- a/frontend/src/components/editor/tabs/IndexProperties.vue
+++ b/frontend/src/components/editor/tabs/IndexProperties.vue
@@ -84,6 +84,13 @@ function updateCol(i: number, field: string, value: string) {
 
     <DynamicColumnList label="Include" :model-value="index.include || []" :columns="columns" @update:model-value="set('include', $event)" />
 
+    <template v-if="index.with?.length">
+      <div class="ip-section-label">Storage Params</div>
+      <div v-for="(p, i) in index.with" :key="i" class="ip-row">
+        <span class="ip-mono">{{ p.name }} = {{ p.value }}</span>
+      </div>
+    </template>
+
     <div class="ip-row">
       <label class="ip-label">WHERE</label>
       <input class="ip-input ip-mono" :value="index.where || ''" placeholder="partial index predicate" @change="set('where', ($event.target as HTMLInputElement).value)" />

--- a/pkg/designer/lint/lint.go
+++ b/pkg/designer/lint/lint.go
@@ -979,8 +979,15 @@ func checkTableNaming(v *validator, schema string, t *pgd.Table) {
 
 func (v *validator) checkNaming(path, name string) {
 	// W007: naming convention
-	if v.naming == "snake_case" && !isSnakeCase(name) {
-		v.warnf(RuleNamingViolation, path, "%q violates snake_case convention", name)
+	switch v.naming {
+	case "snake_case":
+		if !isSnakeCase(name) {
+			v.warnf(RuleNamingViolation, path, "%q violates snake_case convention", name)
+		}
+	case "camelCase":
+		if !isCamelCase(name) {
+			v.warnf(RuleNamingViolation, path, "%q violates camelCase convention", name)
+		}
 	}
 }
 
@@ -990,6 +997,23 @@ func isSnakeCase(name string) bool {
 	}
 	for _, r := range name {
 		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func isCamelCase(name string) bool {
+	if name == "" {
+		return false
+	}
+	// must start with lowercase letter
+	if name[0] < 'a' || name[0] > 'z' {
+		return false
+	}
+	// no underscores allowed
+	for _, r := range name {
+		if r == '_' {
 			return false
 		}
 	}

--- a/pkg/designer/lint/lint_test.go
+++ b/pkg/designer/lint/lint_test.go
@@ -555,6 +555,16 @@ func TestValidate_W007_Naming(t *testing.T) {
 	assert.True(t, hasCode(issues, RuleNamingViolation), "expected W007 for snake_case violation")
 }
 
+func TestValidate_W007_NamingCamelCase(t *testing.T) {
+	p := minProject()
+	p.ProjectMeta.Settings.Naming.Convention = "camelCase"
+	p.Schemas[0].Tables[0].Name = "user_orders"
+	p.Schemas[0].Tables[0].Columns = append(p.Schemas[0].Tables[0].Columns,
+		pgd.Column{Name: "first_name", Type: "text"})
+	issues := Validate(p)
+	assert.True(t, hasCode(issues, RuleNamingViolation), "expected W007 for camelCase violation on snake_case names")
+}
+
 // --- ignore rules ---
 
 func TestValidate_IgnoreRules(t *testing.T) {

--- a/pkg/format/sql/sql.go
+++ b/pkg/format/sql/sql.go
@@ -404,8 +404,12 @@ func extractColumnConstraints(tbl *pgd.Table, col *pg.ColumnDef) {
 		}
 		switch con.Constraint.Contype {
 		case pg.ConstrType_CONSTR_PRIMARY:
+			pkName := con.Constraint.Conname
+			if pkName == "" {
+				pkName = tbl.Name + "_pkey"
+			}
 			tbl.PK = &pgd.PrimaryKey{
-				Name:    con.Constraint.Conname,
+				Name:    pkName,
 				Columns: []pgd.ColRef{{Name: col.Colname}},
 			}
 		case pg.ConstrType_CONSTR_UNIQUE:
@@ -537,7 +541,11 @@ func applyTypeMods(c *pgd.Column, tn *pg.TypeName) {
 func convertTableConstraint(tbl *pgd.Table, con *pg.Constraint) {
 	switch con.Contype {
 	case pg.ConstrType_CONSTR_PRIMARY:
-		pk := pgd.PrimaryKey{Name: con.Conname}
+		pkName := con.Conname
+		if pkName == "" {
+			pkName = tbl.Name + "_pkey"
+		}
+		pk := pgd.PrimaryKey{Name: pkName}
 		for _, k := range con.Keys {
 			if s, ok := k.Node.(*pg.Node_String_); ok {
 				pk.Columns = append(pk.Columns, pgd.ColRef{Name: s.String_.Sval})
@@ -751,7 +759,11 @@ func (c *sqlConverter) convertAlterTable(stmt *pg.AlterTableStmt) { //nolint:goc
 			fk := convertFKConstraint(con.Constraint)
 			schema.Tables[tableIdx].FKs = append(schema.Tables[tableIdx].FKs, fk)
 		case pg.ConstrType_CONSTR_PRIMARY:
-			pk := pgd.PrimaryKey{Name: con.Constraint.Conname}
+			pkName := con.Constraint.Conname
+			if pkName == "" {
+				pkName = schema.Tables[tableIdx].Name + "_pkey"
+			}
+			pk := pgd.PrimaryKey{Name: pkName}
 			for _, k := range con.Constraint.Keys {
 				if s, ok := k.Node.(*pg.Node_String_); ok {
 					pk.Columns = append(pk.Columns, pgd.ColRef{Name: s.String_.Sval})

--- a/pkg/format/sql/testdata/pagila.pgd
+++ b/pkg/format/sql/testdata/pagila.pgd
@@ -197,7 +197,7 @@
       <column name="rental_id" type="integer" nullable="false"></column>
       <column name="amount" type="numeric" precision="5" scale="2" nullable="false"></column>
       <column name="payment_date" type="timestamptz" nullable="false"></column>
-      <pk name="">
+      <pk name="payment_pkey">
         <column name="payment_date"></column>
         <column name="payment_id"></column>
       </pk>

--- a/pkg/format/sql/testdata/pagila_generated.sql
+++ b/pkg/format/sql/testdata/pagila_generated.sql
@@ -140,7 +140,7 @@ CREATE TABLE "payment" (
 	"rental_id" integer NOT NULL,
 	"amount" numeric(5,2) NOT NULL,
 	"payment_date" timestamptz NOT NULL,
-	PRIMARY KEY("payment_date", "payment_id")
+	CONSTRAINT "payment_pkey" PRIMARY KEY("payment_date", "payment_id")
 )
 PARTITION BY RANGE ("payment_date");
 

--- a/pkg/pgd/ddl.go
+++ b/pkg/pgd/ddl.go
@@ -863,6 +863,9 @@ func excludeDef(e *Exclude) string {
 		if el.Expression != "" {
 			target = el.Expression
 		}
+		if el.Opclass != "" {
+			target += " " + el.Opclass
+		}
 		elems = append(elems, fmt.Sprintf("%s WITH %s", target, el.With))
 	}
 	using := ""

--- a/pkg/pgd/ddl_test.go
+++ b/pkg/pgd/ddl_test.go
@@ -718,6 +718,32 @@ func TestGenerateDDL_Exclude(t *testing.T) {
 	assert.Contains(t, ddl, `"during" WITH &&`)
 }
 
+func TestGenerateDDL_ExcludeOpclass(t *testing.T) {
+	p := &Project{
+		Schemas: []Schema{{
+			Name: "public",
+			Tables: []Table{{
+				Name: "reservations",
+				Columns: []Column{
+					{Name: "room_id", Type: "integer"},
+					{Name: "during", Type: "tstzrange"},
+				},
+				Excludes: []Exclude{{
+					Name:  "no_overlap",
+					Using: "gist",
+					Elements: []ExcludeElement{
+						{Column: "room_id", Opclass: "gist_int4_ops", With: "="},
+						{Column: "during", With: "&&"},
+					},
+				}},
+			}},
+		}},
+	}
+	ddl := GenerateDDL(p)
+	assert.Contains(t, ddl, `"room_id" gist_int4_ops WITH =`)
+	assert.Contains(t, ddl, `"during" WITH &&`)
+}
+
 // --- Role / RLS / Policy / Grant ---
 
 func TestGenerateDDL_Role(t *testing.T) {

--- a/pkg/pgd/model.go
+++ b/pkg/pgd/model.go
@@ -331,6 +331,7 @@ type Exclude struct {
 type ExcludeElement struct {
 	Column     string `xml:"column,attr,omitempty"`
 	Expression string `xml:"expression,attr,omitempty"`
+	Opclass    string `xml:"opclass,attr,omitempty"`
 	With       string `xml:"with,attr"`
 }
 

--- a/pkg/rpc/convert.go
+++ b/pkg/rpc/convert.go
@@ -177,7 +177,7 @@ func newTableDetail(p *pgd.Project, t *pgd.Table, schema *pgd.Schema) *TableDeta
 			ed.Where = ex.Where.Value
 		}
 		for _, el := range ex.Elements {
-			ed.Elements = append(ed.Elements, ExcludeElementDetail{Column: el.Column, Expression: el.Expression, With: el.With})
+			ed.Elements = append(ed.Elements, ExcludeElementDetail{Column: el.Column, Expression: el.Expression, Opclass: el.Opclass, With: el.With})
 		}
 		td.Excludes = append(td.Excludes, ed)
 	}

--- a/pkg/rpc/convert.go
+++ b/pkg/rpc/convert.go
@@ -90,7 +90,7 @@ func newObjectItems(p *pgd.Project) []ObjectItem {
 	return items
 }
 
-func newTableDetail(p *pgd.Project, t *pgd.Table, schema *pgd.Schema) *TableDetail {
+func newTableDetail(p *pgd.Project, t *pgd.Table, schema *pgd.Schema) *TableDetail { //nolint:gocognit,gocyclo,cyclop
 	// Build PK and FK column sets
 	pkCols := map[string]bool{}
 	if t.PK != nil {
@@ -173,8 +173,11 @@ func newTableDetail(p *pgd.Project, t *pgd.Table, schema *pgd.Schema) *TableDeta
 	// Excludes
 	for _, ex := range t.Excludes {
 		ed := ExcludeDetail{Name: ex.Name, Using: ex.Using}
+		if ex.Where != nil {
+			ed.Where = ex.Where.Value
+		}
 		for _, el := range ex.Elements {
-			ed.Elements = append(ed.Elements, ExcludeElementDetail{Column: el.Column, With: el.With})
+			ed.Elements = append(ed.Elements, ExcludeElementDetail{Column: el.Column, Expression: el.Expression, With: el.With})
 		}
 		td.Excludes = append(td.Excludes, ed)
 	}
@@ -211,6 +214,11 @@ func newTableDetail(p *pgd.Project, t *pgd.Table, schema *pgd.Schema) *TableDeta
 		}
 		for _, e := range idx.Expressions {
 			id.Expressions = append(id.Expressions, e.Value)
+		}
+		if idx.With != nil {
+			for _, p := range idx.With.Params {
+				id.With = append(id.With, WithParamDetail{Name: p.Name, Value: p.Value})
+			}
 		}
 		if idx.Where != nil {
 			id.Where = idx.Where.Value

--- a/pkg/rpc/input.go
+++ b/pkg/rpc/input.go
@@ -154,33 +154,45 @@ type ExcludeInput struct {
 	Name     string                `json:"name"`
 	Using    string                `json:"using,omitempty"`
 	Elements []ExcludeElementInput `json:"elements"`
+	Where    string                `json:"where,omitempty"`
 }
 
 // ExcludeElementInput is one element of an exclude constraint.
 type ExcludeElementInput struct {
-	Column string `json:"column"`
-	With   string `json:"with"`
+	Column     string `json:"column,omitempty"`
+	Expression string `json:"expression,omitempty"`
+	With       string `json:"with"`
 }
 
 func (e ExcludeInput) toPGD() pgd.Exclude {
 	ex := pgd.Exclude{Name: e.Name, Using: e.Using}
 	for _, el := range e.Elements {
-		ex.Elements = append(ex.Elements, pgd.ExcludeElement{Column: el.Column, With: el.With})
+		ex.Elements = append(ex.Elements, pgd.ExcludeElement{Column: el.Column, Expression: el.Expression, With: el.With})
+	}
+	if e.Where != "" {
+		ex.Where = &pgd.WhereClause{Value: e.Where}
 	}
 	return ex
 }
 
 // IndexInput is an index from the editor.
 type IndexInput struct {
-	Name          string          `json:"name"`
-	Table         string          `json:"table"`
-	Unique        bool            `json:"unique,omitempty"`
-	NullsDistinct bool            `json:"nullsDistinct,omitempty"`
-	Using         string          `json:"using,omitempty"`
-	Columns       []IndexColInput `json:"columns"`
-	Expressions   []string        `json:"expressions,omitempty"`
-	Where         string          `json:"where,omitempty"`
-	Include       []string        `json:"include,omitempty"`
+	Name          string           `json:"name"`
+	Table         string           `json:"table"`
+	Unique        bool             `json:"unique,omitempty"`
+	NullsDistinct bool             `json:"nullsDistinct,omitempty"`
+	Using         string           `json:"using,omitempty"`
+	Columns       []IndexColInput  `json:"columns"`
+	Expressions   []string         `json:"expressions,omitempty"`
+	With          []WithParamInput `json:"with,omitempty"`
+	Where         string           `json:"where,omitempty"`
+	Include       []string         `json:"include,omitempty"`
+}
+
+// WithParamInput is a key-value storage parameter.
+type WithParamInput struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // IndexColInput is an index column with ordering.
@@ -208,6 +220,13 @@ func (idx IndexInput) toPGD() pgd.Index {
 	}
 	for _, e := range idx.Expressions {
 		ix.Expressions = append(ix.Expressions, pgd.Expression{Value: e})
+	}
+	if len(idx.With) > 0 {
+		w := &pgd.With{}
+		for _, p := range idx.With {
+			w.Params = append(w.Params, pgd.WithParam{Name: p.Name, Value: p.Value})
+		}
+		ix.With = w
 	}
 	if idx.Where != "" {
 		ix.Where = &pgd.WhereClause{Value: idx.Where}

--- a/pkg/rpc/input.go
+++ b/pkg/rpc/input.go
@@ -161,13 +161,14 @@ type ExcludeInput struct {
 type ExcludeElementInput struct {
 	Column     string `json:"column,omitempty"`
 	Expression string `json:"expression,omitempty"`
+	Opclass    string `json:"opclass,omitempty"`
 	With       string `json:"with"`
 }
 
 func (e ExcludeInput) toPGD() pgd.Exclude {
 	ex := pgd.Exclude{Name: e.Name, Using: e.Using}
 	for _, el := range e.Elements {
-		ex.Elements = append(ex.Elements, pgd.ExcludeElement{Column: el.Column, Expression: el.Expression, With: el.With})
+		ex.Elements = append(ex.Elements, pgd.ExcludeElement{Column: el.Column, Expression: el.Expression, Opclass: el.Opclass, With: el.With})
 	}
 	if e.Where != "" {
 		ex.Where = &pgd.WhereClause{Value: e.Where}

--- a/pkg/rpc/model.go
+++ b/pkg/rpc/model.go
@@ -268,6 +268,7 @@ type ExcludeDetail struct {
 type ExcludeElementDetail struct {
 	Column     string `json:"column,omitempty"`
 	Expression string `json:"expression,omitempty"`
+	Opclass    string `json:"opclass,omitempty"`
 	With       string `json:"with"`
 }
 

--- a/pkg/rpc/model.go
+++ b/pkg/rpc/model.go
@@ -261,12 +261,14 @@ type ExcludeDetail struct {
 	Name     string                 `json:"name"`
 	Using    string                 `json:"using,omitempty"`
 	Elements []ExcludeElementDetail `json:"elements"`
+	Where    string                 `json:"where,omitempty"`
 }
 
 // ExcludeElementDetail holds one element of an exclude constraint.
 type ExcludeElementDetail struct {
-	Column string `json:"column"`
-	With   string `json:"with"`
+	Column     string `json:"column,omitempty"`
+	Expression string `json:"expression,omitempty"`
+	With       string `json:"with"`
 }
 
 // FKDetail holds foreign key data.
@@ -337,14 +339,21 @@ type ObjectItem struct {
 
 // IndexDetail holds index data.
 type IndexDetail struct {
-	Name          string           `json:"name"`
-	Unique        bool             `json:"unique,omitempty"`
-	NullsDistinct bool             `json:"nullsDistinct,omitempty"`
-	Using         string           `json:"using,omitempty"`
-	Columns       []IndexColDetail `json:"columns"`
-	Expressions   []string         `json:"expressions,omitempty"`
-	Where         string           `json:"where,omitempty"`
-	Include       []string         `json:"include,omitempty"`
+	Name          string            `json:"name"`
+	Unique        bool              `json:"unique,omitempty"`
+	NullsDistinct bool              `json:"nullsDistinct,omitempty"`
+	Using         string            `json:"using,omitempty"`
+	Columns       []IndexColDetail  `json:"columns"`
+	Expressions   []string          `json:"expressions,omitempty"`
+	With          []WithParamDetail `json:"with,omitempty"`
+	Where         string            `json:"where,omitempty"`
+	Include       []string          `json:"include,omitempty"`
+}
+
+// WithParamDetail holds a key-value storage parameter.
+type WithParamDetail struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // IndexColDetail holds index column with ordering metadata.

--- a/pkg/rpc/rpc_zenrpc.go
+++ b/pkg/rpc/rpc_zenrpc.go
@@ -1568,6 +1568,10 @@ func (ProjectService) SMD() smd.ServiceInfo {
 										"$ref": "#/definitions/ExcludeElementDetail",
 									},
 								},
+								{
+									Name: "where",
+									Type: smd.String,
+								},
 							},
 						},
 						"ExcludeElementDetail": {
@@ -1575,6 +1579,10 @@ func (ProjectService) SMD() smd.ServiceInfo {
 							Properties: smd.PropertyList{
 								{
 									Name: "column",
+									Type: smd.String,
+								},
+								{
+									Name: "expression",
 									Type: smd.String,
 								},
 								{
@@ -1666,6 +1674,13 @@ func (ProjectService) SMD() smd.ServiceInfo {
 									},
 								},
 								{
+									Name: "with",
+									Type: smd.Array,
+									Items: map[string]string{
+										"$ref": "#/definitions/WithParamDetail",
+									},
+								},
+								{
 									Name: "where",
 									Type: smd.String,
 								},
@@ -1697,6 +1712,19 @@ func (ProjectService) SMD() smd.ServiceInfo {
 								},
 								{
 									Name: "opclass",
+									Type: smd.String,
+								},
+							},
+						},
+						"WithParamDetail": {
+							Type: "object",
+							Properties: smd.PropertyList{
+								{
+									Name: "name",
+									Type: smd.String,
+								},
+								{
+									Name: "value",
 									Type: smd.String,
 								},
 							},
@@ -2189,6 +2217,10 @@ Used for saving DDL, diff patches, and other generated text.`,
 											"$ref": "#/definitions/ExcludeElementInput",
 										},
 									},
+									{
+										Name: "where",
+										Type: smd.String,
+									},
 								},
 							},
 							"ExcludeElementInput": {
@@ -2196,6 +2228,10 @@ Used for saving DDL, diff patches, and other generated text.`,
 								Properties: smd.PropertyList{
 									{
 										Name: "column",
+										Type: smd.String,
+									},
+									{
+										Name: "expression",
 										Type: smd.String,
 									},
 									{
@@ -2253,6 +2289,13 @@ Used for saving DDL, diff patches, and other generated text.`,
 										},
 									},
 									{
+										Name: "with",
+										Type: smd.Array,
+										Items: map[string]string{
+											"$ref": "#/definitions/WithParamInput",
+										},
+									},
+									{
 										Name: "where",
 										Type: smd.String,
 									},
@@ -2282,6 +2325,19 @@ Used for saving DDL, diff patches, and other generated text.`,
 									},
 									{
 										Name: "opclass",
+										Type: smd.String,
+									},
+								},
+							},
+							"WithParamInput": {
+								Type: "object",
+								Properties: smd.PropertyList{
+									{
+										Name: "name",
+										Type: smd.String,
+									},
+									{
+										Name: "value",
 										Type: smd.String,
 									},
 								},
@@ -2596,6 +2652,10 @@ Used for saving DDL, diff patches, and other generated text.`,
 										"$ref": "#/definitions/ExcludeElementDetail",
 									},
 								},
+								{
+									Name: "where",
+									Type: smd.String,
+								},
 							},
 						},
 						"ExcludeElementDetail": {
@@ -2603,6 +2663,10 @@ Used for saving DDL, diff patches, and other generated text.`,
 							Properties: smd.PropertyList{
 								{
 									Name: "column",
+									Type: smd.String,
+								},
+								{
+									Name: "expression",
 									Type: smd.String,
 								},
 								{
@@ -2694,6 +2758,13 @@ Used for saving DDL, diff patches, and other generated text.`,
 									},
 								},
 								{
+									Name: "with",
+									Type: smd.Array,
+									Items: map[string]string{
+										"$ref": "#/definitions/WithParamDetail",
+									},
+								},
+								{
 									Name: "where",
 									Type: smd.String,
 								},
@@ -2725,6 +2796,19 @@ Used for saving DDL, diff patches, and other generated text.`,
 								},
 								{
 									Name: "opclass",
+									Type: smd.String,
+								},
+							},
+						},
+						"WithParamDetail": {
+							Type: "object",
+							Properties: smd.PropertyList{
+								{
+									Name: "name",
+									Type: smd.String,
+								},
+								{
+									Name: "value",
 									Type: smd.String,
 								},
 							},
@@ -3069,6 +3153,10 @@ It does NOT modify the project — only computes the diff.`,
 											"$ref": "#/definitions/ExcludeElementInput",
 										},
 									},
+									{
+										Name: "where",
+										Type: smd.String,
+									},
 								},
 							},
 							"ExcludeElementInput": {
@@ -3076,6 +3164,10 @@ It does NOT modify the project — only computes the diff.`,
 								Properties: smd.PropertyList{
 									{
 										Name: "column",
+										Type: smd.String,
+									},
+									{
+										Name: "expression",
 										Type: smd.String,
 									},
 									{
@@ -3133,6 +3225,13 @@ It does NOT modify the project — only computes the diff.`,
 										},
 									},
 									{
+										Name: "with",
+										Type: smd.Array,
+										Items: map[string]string{
+											"$ref": "#/definitions/WithParamInput",
+										},
+									},
+									{
 										Name: "where",
 										Type: smd.String,
 									},
@@ -3162,6 +3261,19 @@ It does NOT modify the project — only computes the diff.`,
 									},
 									{
 										Name: "opclass",
+										Type: smd.String,
+									},
+								},
+							},
+							"WithParamInput": {
+								Type: "object",
+								Properties: smd.PropertyList{
+									{
+										Name: "name",
+										Type: smd.String,
+									},
+									{
+										Name: "value",
 										Type: smd.String,
 									},
 								},


### PR DESCRIPTION
## Summary
- Add exclude expression/where and index WITH params to RPC layer
- Make exclude constraints fully editable in UI
- Show exclude expression/where and index WITH params in table editor
- Fix SQL import: generate default `{table}_pkey` name for unnamed PK constraints
- Lint W007 now catches camelCase convention violations (previously only snake_case)

## Test plan
- [ ] Open a `.sql` file with inline `PRIMARY KEY` (no CONSTRAINT name) — verify PK name shows in UI
- [ ] Open a `.pdd` file — verify PK constraints still have names
- [ ] Set naming convention to camelCase — verify snake_case names are flagged as W007
- [ ] Edit exclude constraints in table editor — verify expression/where fields work
- [ ] Check index WITH params display in editor