### PR TITLE
add output flag to the diff command

### DIFF
--- a/cmd/pgdesigner/commands.go
+++ b/cmd/pgdesigner/commands.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -177,8 +178,9 @@ func printIssues(issues []lint.Issue, errors int, outputFmt string) {
 func runDiff(args []string) {
 	fs := flag.NewFlagSet("diff", flag.ExitOnError)
 	outputFmt := fs.String("f", "sql", "output format: sql, json")
+	outputFile := fs.String("o", "", "a pathname of an output file. Creates a file if it doesn't exist, overwrites otherwise. Output format is determined by the -f flag")
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: pgdesigner diff [-f sql|json] <old.pgd> <new.pgd>\n\nFlags:\n")
+		fmt.Fprintf(os.Stderr, "Usage: pgdesigner diff [-f sql|json] [-o file] <old.pgd> <new.pgd>\n\nFlags:\n")
 		fs.PrintDefaults()
 	}
 	_ = fs.Parse(args)
@@ -204,13 +206,28 @@ func runDiff(args []string) {
 		return
 	}
 
+	var w io.Writer = os.Stdout
+
+	if outputFile != nil && *outputFile != "" {
+		f, err := os.Create(*outputFile)
+		if err != nil {
+			log.Fatalf("failed to open %s: %v", *outputFile, err)
+		}
+		defer f.Close()
+		w = io.MultiWriter(os.Stdout, f)
+	}
+
 	switch *outputFmt {
 	case "json":
-		enc := json.NewEncoder(os.Stdout)
+		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
-		_ = enc.Encode(result.Changes)
+		if err := enc.Encode(result.Changes); err != nil {
+			log.Fatalf("failed to encode JSON: %v", err)
+		}
 	default:
-		fmt.Print(result.SQL())
+		if _, err := fmt.Fprint(w, result.SQL()); err != nil {
+			log.Fatalf("failed to write output: %v", err)
+		}
 	}
 
 	if result.HasHazards() {


### PR DESCRIPTION
Hello,
While scrolling through the features on pgdesigner's website i saw an example use of "-o" flag. I then attempted to generate a migration locally with that option only to find out that the flag is actually missing in the code.

<img width="933" height="146" alt="CleanShot 2026-04-23 at 20 43 23" src="https://github.com/user-attachments/assets/4f8ce512-e583-429e-a773-9767f761a9f8" />

I thought it could actually be useful so i tried to implement it. Also i think that the silent flag to omit the output to stdout would be a great fit in combination with the -o flag but i skipped implementing it yet.

Let me know what you think.

